### PR TITLE
feat: add payment intent API route

### DIFF
--- a/app/api/billing/payment-intents/route.ts
+++ b/app/api/billing/payment-intents/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: '2022-11-15',
+});
+
+export async function POST(request: Request) {
+  try {
+    const { amount } = await request.json();
+
+    if (typeof amount !== 'number' || amount <= 0) {
+      return NextResponse.json({ error: 'Invalid amount' }, { status: 400 });
+    }
+
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount,
+      currency: 'usd',
+      automatic_payment_methods: { enabled: true },
+    });
+
+    return NextResponse.json({ clientSecret: paymentIntent.client_secret });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add Next.js route for creating Stripe payment intents

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b670457b6c832892a6423f3f294f0a