### PR TITLE
feat(auth): make session strategy configurable

### DIFF
--- a/authOptions.ts
+++ b/authOptions.ts
@@ -1,0 +1,31 @@
+import type { AuthOptions, SessionStrategy } from "next-auth";
+import type { Adapter } from "next-auth/adapters";
+
+const isProd = process.env.NODE_ENV === "production";
+
+// Allow choosing between JWT and database sessions via environment variable
+const sessionStrategy: SessionStrategy =
+  process.env.SESSION_STRATEGY === "database" ? "database" : "jwt";
+
+export const buildAuthOptions = (adapter?: Adapter): AuthOptions => {
+  const options: AuthOptions = {
+    session: {
+      strategy: sessionStrategy,
+    },
+    cookies: {
+      sessionToken: {
+        options: {
+          secure: isProd,
+          httpOnly: true,
+          sameSite: "lax",
+        },
+      },
+    },
+  };
+
+  if (sessionStrategy === "database" && adapter) {
+    options.adapter = adapter;
+  }
+
+  return options;
+};


### PR DESCRIPTION
## Summary
- allow switching between JWT and database sessions via environment variable
- secure session cookie with httpOnly, sameSite=lax, and secure flag in production

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6703fa09c8328b46c2fc411b43284