### PR TITLE
Add credentials auth configuration

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,49 @@
+import NextAuth from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+import bcrypt from "bcrypt";
+
+// Example in-memory user store. In a real application this should query the database.
+const users = [
+  {
+    id: "1",
+    email: "demo@example.com",
+    // bcrypt hash for the string "password"
+    passwordHash: "$2b$10$CwTycUXWue0Thq9StjUM0uJ8b.C/UG6u.ZYf.Q3u8b6hqhqJv/1.W"
+  }
+];
+
+export default NextAuth({
+  providers: [
+    Credentials({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" }
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials?.password) {
+          return null;
+        }
+
+        const user = users.find((u) => u.email === credentials.email);
+        if (!user) {
+          return null;
+        }
+
+        const isValid = await bcrypt.compare(
+          credentials.password,
+          user.passwordHash
+        );
+        if (!isValid) {
+          return null;
+        }
+
+        // Returning a user object creates a session
+        return { id: user.id, email: user.email };
+      }
+    })
+  ],
+  session: {
+    strategy: "jwt"
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "simple-invoice-website",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "bcrypt": "^5.1.0",
+    "next-auth": "^4.22.1"
+  }
+}


### PR DESCRIPTION
## Summary
- configure Auth.js with a Credentials provider
- verify passwords with bcrypt against stored hashes to create sessions

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b6703f7bc4832888b0ed838c3aa3e8