### PR TITLE
feat: add Prisma client singleton

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from '@prisma/client'
+
+// Ensure a single PrismaClient instance across hot reloads
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+
+export default prisma


### PR DESCRIPTION
## Summary
- add a PrismaClient singleton to reuse connection across hot reloads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6703957008328863bfd55828380b2