### PR TITLE
Add Node/Next.js .gitignore and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm run build
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# dependencies
+node_modules/
+
+# testing
+coverage/
+
+# Next.js build output
+.next/
+out/
+
+# production
+build/
+dist/
+
+# misc
+.DS_Store
+
+# debug logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# local env files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel/


### PR DESCRIPTION
## Summary
- ignore Node.js dependencies, logs, env files, and Next.js build outputs
- run npm install, build, and test on pull requests via GitHub Actions

## Testing
- `npm run build` *(fails: ENOENT package.json)*
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b67029f0448328bc831a484a489da6