### PR TITLE
Add audit log schema and admin viewer

### DIFF
--- a/admin/AuditLogViewer.tsx
+++ b/admin/AuditLogViewer.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from "react";
+import { AuditLog } from "../db/schema/audit_logs";
+import { getAuditLogsByTenant } from "../db/auditLogs";
+
+export interface AuditLogViewerProps {
+  tenantId: string;
+  fetchLogs?: (tenantId: string) => Promise<AuditLog[]>;
+}
+
+// Displays audit log entries for the given tenant
+export const AuditLogViewer: React.FC<AuditLogViewerProps> = ({ tenantId, fetchLogs }) => {
+  const [logs, setLogs] = useState<AuditLog[]>([]);
+  const loader = fetchLogs ?? getAuditLogsByTenant;
+
+  useEffect(() => {
+    loader(tenantId).then(setLogs);
+  }, [tenantId, loader]);
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>User</th>
+          <th>Action</th>
+          <th>Record</th>
+        </tr>
+      </thead>
+      <tbody>
+        {logs.map((log) => (
+          <tr key={log.id}>
+            <td>{new Date(log.createdAt).toLocaleString()}</td>
+            <td>{log.userId}</td>
+            <td>{log.action}</td>
+            <td>{`${log.recordType}#${log.recordId}`}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/db/auditLogs.ts
+++ b/db/auditLogs.ts
@@ -1,0 +1,8 @@
+import { eq } from "drizzle-orm";
+import { auditLogs, AuditLog } from "./schema/audit_logs";
+import { db } from "./client"; // assumed database client
+
+// Fetches audit log entries for a particular tenant
+export async function getAuditLogsByTenant(tenantId: string): Promise<AuditLog[]> {
+  return db.select().from(auditLogs).where(eq(auditLogs.tenantId, tenantId));
+}

--- a/db/client.ts
+++ b/db/client.ts
@@ -1,0 +1,3 @@
+// Placeholder database client. In a real application this would
+// be configured with a connection to the underlying database.
+export const db: any = {};

--- a/db/schema/audit_logs.ts
+++ b/db/schema/audit_logs.ts
@@ -1,0 +1,18 @@
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { sql, InferModel } from "drizzle-orm";
+
+// Audit log captures who did what and when against which record
+export const auditLogs = sqliteTable("audit_logs", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  tenantId: text("tenant_id").notNull(),
+  userId: text("user_id").notNull(),
+  action: text("action").notNull(),
+  recordType: text("record_type").notNull(),
+  recordId: text("record_id").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .default(sql`CURRENT_TIMESTAMP`)
+    .notNull(),
+});
+
+export type AuditLog = InferModel<typeof auditLogs>;
+export type NewAuditLog = InferModel<typeof auditLogs, "insert">;


### PR DESCRIPTION
## Summary
- add audit log schema capturing user, action, time, and record
- add database helper for retrieving tenant-scoped logs
- add admin UI component to display audit logs per tenant

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b68e1a70788328ab8aa88cfd7de66d