### PR TITLE
Implement account lockout with admin unlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+venv/
+instance/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # simple-invoice-website
 basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+## Development
+
+This demo Flask app supports a simple account lockout mechanism.
+After three failed login attempts, the account is locked and a notification
+email is sent (errors are logged to console if email sending fails).
+Visit `/admin` to unlock accounts.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,77 @@
+from flask import Flask, request, render_template, redirect, url_for, flash
+from models import db, User
+import os
+from email.message import EmailMessage
+import smtplib
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///db.sqlite3'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['SECRET_KEY'] = 'dev'
+
+db.init_app(app)
+
+MAX_FAILED_LOGINS = 3
+
+
+def send_notification(user: User) -> None:
+    """Send email notifying the user that their account was locked."""
+    sender = os.environ.get('EMAIL_SENDER', 'noreply@example.com')
+    msg = EmailMessage()
+    msg['Subject'] = 'Account locked'
+    msg['From'] = sender
+    msg['To'] = user.email
+    msg.set_content(
+        f"Hello {user.username}, your account has been locked due to too many failed login attempts."
+    )
+    try:
+        with smtplib.SMTP('localhost') as server:
+            server.send_message(msg)
+    except Exception:
+        # In this environment we may not have an SMTP server; log to console instead
+        print(f"Failed to send email to {user.email}")
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user is None or not user.check_password(password):
+            if user:
+                user.failed_logins += 1
+                if user.failed_logins >= MAX_FAILED_LOGINS:
+                    user.locked = True
+                    send_notification(user)
+                db.session.commit()
+            flash('Invalid credentials')
+            return redirect(url_for('login'))
+        if user.locked:
+            flash('Account locked')
+            return redirect(url_for('login'))
+        user.failed_logins = 0
+        db.session.commit()
+        return 'Logged in'
+    return render_template('login.html')
+
+
+@app.route('/admin', methods=['GET', 'POST'])
+def admin():
+    if request.method == 'POST':
+        username = request.form['username']
+        user = User.query.filter_by(username=username, locked=True).first()
+        if user:
+            user.locked = False
+            user.failed_logins = 0
+            db.session.commit()
+            flash('User unlocked')
+        return redirect(url_for('admin'))
+    locked_users = User.query.filter_by(locked=True).all()
+    return render_template('admin.html', users=locked_users)
+
+
+if __name__ == '__main__':
+    with app.app_context():
+        db.create_all()
+    app.run(debug=True)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,20 @@
+from flask_sqlalchemy import SQLAlchemy
+from werkzeug.security import generate_password_hash, check_password_hash
+
+# Initialize SQLAlchemy without app; app will call init_app
+
+db = SQLAlchemy()
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    failed_logins = db.Column(db.Integer, default=0)
+    locked = db.Column(db.Boolean, default=False)
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=2.2
+Flask-SQLAlchemy>=3.0
+pytest>=7.0

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>Admin</title>
+<h1>Locked Users</h1>
+<ul>
+{% for user in users %}
+  <li>{{ user.username }}
+    <form method="post" style="display:inline">
+      <input type="hidden" name="username" value="{{ user.username }}">
+      <button type="submit">Unlock</button>
+    </form>
+  </li>
+{% else %}
+  <li>No locked users</li>
+{% endfor %}
+</ul>
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+    <ul>
+    {% for message in messages %}
+      <li>{{ message }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endwith %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<title>Login</title>
+<h1>Login</h1>
+<form method="post">
+  <input name="username" placeholder="Username">
+  <input name="password" type="password" placeholder="Password">
+  <input type="submit" value="Login">
+</form>
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+    <ul>
+    {% for message in messages %}
+      <li>{{ message }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endwith %}

--- a/tests/test_lockout.py
+++ b/tests/test_lockout.py
@@ -1,0 +1,62 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app, db, User, MAX_FAILED_LOGINS
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+        user = User(username='user', email='user@example.com')
+        user.set_password('password')
+        db.session.add(user)
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def login(client, username, password):
+    return client.post('/login', data={'username': username, 'password': password}, follow_redirects=True)
+
+
+def test_lockout_after_failed_attempts(client, monkeypatch):
+    sent = {}
+
+    def fake_send(user):
+        sent['email'] = user.email
+
+    monkeypatch.setattr('app.send_notification', fake_send)
+
+    for _ in range(MAX_FAILED_LOGINS):
+        login(client, 'user', 'wrong')
+
+    # account should be locked and email sent
+    with app.app_context():
+        user = User.query.filter_by(username='user').first()
+        assert user.locked
+        assert sent['email'] == 'user@example.com'
+
+
+def test_admin_unlock(client):
+    for _ in range(MAX_FAILED_LOGINS):
+        login(client, 'user', 'wrong')
+
+    # unlock via admin interface
+    client.post('/admin', data={'username': 'user'}, follow_redirects=True)
+
+    with app.app_context():
+        user = User.query.filter_by(username='user').first()
+        assert not user.locked
+        assert user.failed_logins == 0
+
+    # user can log in successfully now
+    response = login(client, 'user', 'password')
+    assert b'Logged in' in response.data


### PR DESCRIPTION
## Summary
- Track failed login attempts and lock accounts after 3 failures
- Notify users via email when locked
- Add admin page to view and unlock locked users
- Test lockout and unlock workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b68e1c0d9483288dc545dd99769ca6