### PR TITLE
Add CSV export templates and admin download page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+dist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # simple-invoice-website
-basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+Basic rent invoicing system that records payments and generates printable/PDF rent receipts.
+
+## Accounting Exports
+
+An admin dashboard is available at `/admin` when running the server. From there CSV files matching QuickBooks or Xero import schemas can be downloaded for manual upload into those systems.
+
+Future work will push invoice data directly to the QuickBooks and Xero APIs once credentials and synchronization workflows are finalized.
+
+## Development
+
+Install dependencies and build the project:
+
+```bash
+npm install
+npm run build
+npm start
+```

--- a/lib/accounting/exports.ts
+++ b/lib/accounting/exports.ts
@@ -1,0 +1,77 @@
+export interface Invoice {
+  id: string;
+  customer: string;
+  issueDate: string; // ISO date
+  dueDate: string;   // ISO date
+  item: string;
+  quantity: number;
+  rate: number;
+}
+
+function escapeCSV(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return '"' + value.replace(/"/g, '""') + '"';
+  }
+  return value;
+}
+
+function toCSV(headers: string[], rows: string[][]): string {
+  const data = [headers, ...rows];
+  return data.map(row => row.map(escapeCSV).join(',')).join('\n');
+}
+
+export function exportQuickBooksCSV(invoices: Invoice[]): string {
+  const headers = [
+    'Invoice Number',
+    'Customer',
+    'Invoice Date',
+    'Due Date',
+    'Item',
+    'Qty',
+    'Rate',
+    'Amount'
+  ];
+
+  const rows = invoices.map(inv => [
+    inv.id,
+    inv.customer,
+    inv.issueDate,
+    inv.dueDate,
+    inv.item,
+    inv.quantity.toString(),
+    inv.rate.toFixed(2),
+    (inv.quantity * inv.rate).toFixed(2)
+  ]);
+
+  return toCSV(headers, rows);
+}
+
+export function exportXeroCSV(invoices: Invoice[]): string {
+  const headers = [
+    'Contact Name',
+    'Invoice Number',
+    'Invoice Date',
+    'Due Date',
+    'Item Code',
+    'Description',
+    'Quantity',
+    'Unit Amount',
+    'Account Code',
+    'Tax Type'
+  ];
+
+  const rows = invoices.map(inv => [
+    inv.customer,
+    inv.id,
+    inv.issueDate,
+    inv.dueDate,
+    inv.item,
+    inv.item,
+    inv.quantity.toString(),
+    inv.rate.toFixed(2),
+    '',
+    'NONE'
+  ]);
+
+  return toCSV(headers, rows);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "simple-invoice-website",
+  "version": "0.1.0",
+  "main": "dist/server.js",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "test": "tsc --noEmit"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.3",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Accounting Exports</title>
+</head>
+<body>
+<h1>Accounting Exports</h1>
+<ul>
+  <li><a href="/exports/quickbooks">Download QuickBooks CSV</a></li>
+  <li><a href="/exports/xero">Download Xero CSV</a></li>
+</ul>
+<p>Future versions will push invoices directly to QuickBooks and Xero via their APIs.</p>
+</body>
+</html>

--- a/server.ts
+++ b/server.ts
@@ -1,0 +1,49 @@
+import express, { Request, Response } from 'express';
+import path from 'path';
+import { exportQuickBooksCSV, exportXeroCSV, Invoice } from './lib/accounting/exports';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// serve admin page
+app.get('/admin', (_req: Request, res: Response) => {
+  res.sendFile(path.join(__dirname, 'public', 'admin.html'));
+});
+
+// CSV export endpoint
+app.get('/exports/:type', (req: Request, res: Response) => {
+  const sample: Invoice[] = [
+    {
+      id: 'INV-001',
+      customer: 'Sample Customer',
+      issueDate: new Date().toISOString().slice(0, 10),
+      dueDate: new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10),
+      item: 'Service',
+      quantity: 1,
+      rate: 100
+    }
+  ];
+
+  const type = req.params.type;
+  let csv: string;
+  let filename: string;
+
+  if (type === 'quickbooks') {
+    csv = exportQuickBooksCSV(sample);
+    filename = 'quickbooks.csv';
+  } else if (type === 'xero') {
+    csv = exportXeroCSV(sample);
+    filename = 'xero.csv';
+  } else {
+    res.status(400).send('Unknown export type');
+    return;
+  }
+
+  res.header('Content-Type', 'text/csv');
+  res.attachment(filename);
+  res.send(csv);
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}/admin`);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["server.ts", "lib/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add QuickBooks and Xero CSV export helpers
- serve admin page with links to download accounting CSVs
- document future API integration plans

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b68e20c1b88328b6c6e571731a4311