### PR TITLE
feat: add stripe webhook route

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { headers } from 'next/headers';
+import { PrismaClient } from '@prisma/client';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2022-11-15',
+});
+
+const prisma = new PrismaClient();
+
+export async function POST(req: Request) {
+  const body = await req.text();
+  const signature = headers().get('stripe-signature');
+
+  let event: Stripe.Event;
+
+  try {
+    if (!signature) {
+      throw new Error('Missing stripe signature');
+    }
+    event = stripe.webhooks.constructEvent(
+      body,
+      signature,
+      process.env.STRIPE_WEBHOOK_SECRET!
+    );
+  } catch (err) {
+    console.error('Error verifying Stripe signature', err);
+    return new Response(
+      `Webhook Error: ${(err as Error).message}`,
+      { status: 400 }
+    );
+  }
+
+  if (event.type === 'payment_intent.succeeded') {
+    const paymentIntent = event.data.object as Stripe.PaymentIntent;
+    const invoiceId = paymentIntent.metadata?.invoiceId;
+    if (invoiceId) {
+      await prisma.invoice.update({
+        where: { id: invoiceId },
+        data: { status: 'PAID' },
+      });
+    }
+  }
+
+  return NextResponse.json({ received: true });
+}


### PR DESCRIPTION
## Summary
- handle Stripe webhook with signature verification
- mark invoices paid after successful payment intents

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b670476d8c8328808e2233ba3660a8