### PR TITLE
Add invoice layout with payment details and print/PDF actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # simple-invoice-website
-basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+Basic rent invoicing system that records payments and generates printable/PDF rent receipts.
+
+## Usage
+
+Open `index.html` in a browser to view the sample invoice. When an invoice's status is `PAID`,
+its payment metadata is displayed along with buttons to print the invoice or download it as a PDF.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,61 @@
+const invoice = {
+  number: 'INV-001',
+  status: 'PAID',
+  items: [
+    { description: 'September Rent', amount: 1200 },
+    { description: 'Utilities', amount: 150 }
+  ],
+  payment: {
+    date: '2025-09-01',
+    method: 'Credit Card',
+    reference: 'TX12345'
+  }
+};
+
+function renderInvoice() {
+  document.getElementById('invoice-number').textContent = invoice.number;
+  document.getElementById('invoice-status').textContent = invoice.status;
+
+  const tbody = document.querySelector('#items tbody');
+  invoice.items.forEach(item => {
+    const tr = document.createElement('tr');
+    const tdDesc = document.createElement('td');
+    tdDesc.textContent = item.description;
+    const tdAmount = document.createElement('td');
+    tdAmount.textContent = `$${item.amount.toFixed(2)}`;
+    tr.appendChild(tdDesc);
+    tr.appendChild(tdAmount);
+    tbody.appendChild(tr);
+  });
+
+  const total = invoice.items.reduce((sum, item) => sum + item.amount, 0);
+  document.getElementById('total').textContent = total.toFixed(2);
+
+  if (invoice.status === 'PAID') {
+    document.getElementById('actions').classList.remove('hidden');
+    const pm = document.getElementById('payment-metadata');
+    pm.classList.remove('hidden');
+    document.getElementById('payment-date').textContent = invoice.payment.date;
+    document.getElementById('payment-method').textContent = invoice.payment.method;
+    document.getElementById('payment-reference').textContent = invoice.payment.reference;
+  }
+}
+
+renderInvoice();
+
+document.getElementById('print-btn').addEventListener('click', () => {
+  window.print();
+});
+
+document.getElementById('pdf-btn').addEventListener('click', async () => {
+  const { jsPDF } = window.jspdf;
+  const invoiceElement = document.getElementById('invoice');
+  const canvas = await html2canvas(invoiceElement);
+  const imgData = canvas.toDataURL('image/png');
+  const pdf = new jsPDF();
+  const imgProps = pdf.getImageProperties(imgData);
+  const pdfWidth = pdf.internal.pageSize.getWidth();
+  const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+  pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
+  pdf.save(`${invoice.number}.pdf`);
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Invoice</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+</head>
+<body>
+  <div id="invoice">
+    <h1>Invoice #<span id="invoice-number"></span></h1>
+    <div>Status: <span id="invoice-status"></span></div>
+    <div id="payment-metadata" class="hidden">
+      <h2>Payment Details</h2>
+      <ul>
+        <li>Paid on: <span id="payment-date"></span></li>
+        <li>Method: <span id="payment-method"></span></li>
+        <li>Reference: <span id="payment-reference"></span></li>
+      </ul>
+    </div>
+    <table id="items">
+      <thead>
+        <tr><th>Description</th><th>Amount</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <div id="total-row">Total: $<span id="total"></span></div>
+  </div>
+  <div id="actions" class="hidden">
+    <button id="print-btn">Print</button>
+    <button id="pdf-btn">Download PDF</button>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,26 @@
+body {
+  font-family: Arial, sans-serif;
+}
+#invoice {
+  max-width: 600px;
+  margin: auto;
+  border: 1px solid #ccc;
+  padding: 20px;
+}
+#items {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+#items th, #items td {
+  text-align: left;
+  padding: 4px;
+  border-bottom: 1px solid #eee;
+}
+#actions {
+  margin-top: 20px;
+  text-align: center;
+}
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- render sample invoice with line items and totals
- display payment metadata and show print/PDF options when invoice status is `PAID`
- document usage for viewing invoice

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b67057cad08328ba8e59dc155b474d