### PR TITLE
Add skeleton UI with empty states and error messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # simple-invoice-website
 basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+## Development
+
+Open `index.html` in a browser to view a demo interface. The demo includes:
+
+- Skeleton placeholders while invoice data loads
+- Empty-state messaging when no invoices are available
+- Descriptive error handling for failed fetches and form validation

--- a/app.js
+++ b/app.js
@@ -1,0 +1,75 @@
+function loadInvoices() {
+  const list = document.getElementById('invoice-list');
+  const empty = document.getElementById('list-empty');
+  const error = document.getElementById('list-error');
+
+  // simulate loading delay
+  setTimeout(() => {
+    list.classList.remove('skeleton');
+    list.innerHTML = '';
+    const fail = Math.random() < 0.2; // 20% chance of failure
+    if (fail) {
+      error.textContent = 'Failed to load invoices.';
+      error.classList.remove('hidden');
+      return;
+    }
+    const invoices = [];
+    if (invoices.length === 0) {
+      empty.classList.remove('hidden');
+    } else {
+      invoices.forEach(inv => {
+        const li = document.createElement('li');
+        li.textContent = `${inv.customer} - $${inv.amount}`;
+        list.appendChild(li);
+      });
+    }
+  }, 1500);
+}
+
+function setupForm() {
+  const form = document.getElementById('invoice-form');
+  const list = document.getElementById('invoice-list');
+  const empty = document.getElementById('list-empty');
+  const formError = document.getElementById('form-error');
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    formError.classList.add('hidden');
+    document.querySelectorAll('.error-message').forEach(s => s.textContent = '');
+
+    const customer = document.getElementById('customer');
+    const amount = document.getElementById('amount');
+    const errors = {};
+    if (!customer.value.trim()) errors.customer = 'Customer name is required.';
+    if (!amount.value) errors.amount = 'Amount is required.';
+
+    if (Object.keys(errors).length) {
+      Object.entries(errors).forEach(([key, msg]) => {
+        const span = document.querySelector(`.error-message[data-for="${key}"]`);
+        if (span) span.textContent = msg;
+      });
+      return;
+    }
+
+    form.classList.add('submitting');
+    setTimeout(() => {
+      form.classList.remove('submitting');
+      const fail = Math.random() < 0.2;
+      if (fail) {
+        formError.textContent = 'Unable to save invoice. Please try again.';
+        formError.classList.remove('hidden');
+        return;
+      }
+      const li = document.createElement('li');
+      li.textContent = `${customer.value} - $${parseFloat(amount.value).toFixed(2)}`;
+      list.appendChild(li);
+      empty.classList.add('hidden');
+      form.reset();
+    }, 1000);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadInvoices();
+  setupForm();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Simple Invoice</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Invoices</h1>
+  <ul id="invoice-list" class="skeleton">
+    <li class="skeleton-item"></li>
+    <li class="skeleton-item"></li>
+    <li class="skeleton-item"></li>
+  </ul>
+  <div id="list-empty" class="empty hidden">No invoices found.</div>
+  <div id="list-error" class="error hidden"></div>
+
+  <h2>Create Invoice</h2>
+  <form id="invoice-form">
+    <label>
+      Customer Name
+      <input type="text" id="customer" />
+      <span class="error-message" data-for="customer"></span>
+    </label>
+    <label>
+      Amount
+      <input type="number" id="amount" />
+      <span class="error-message" data-for="amount"></span>
+    </label>
+    <button type="submit">Create</button>
+    <div id="form-error" class="error hidden"></div>
+  </form>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,71 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+}
+
+ul {
+  padding: 0;
+  list-style: none;
+}
+
+.hidden {
+  display: none;
+}
+
+.error {
+  color: #b00020;
+  margin-top: 0.5rem;
+}
+
+.error-message {
+  color: #b00020;
+  display: block;
+  font-size: 0.875rem;
+  height: 1rem;
+}
+
+.empty {
+  color: #555;
+  margin-top: 1rem;
+}
+
+.skeleton-item {
+  height: 1rem;
+  margin: 0.5rem 0;
+  background: linear-gradient(90deg, #eee, #ddd, #eee);
+  background-size: 200% 100%;
+  animation: loading 1.5s infinite;
+}
+
+@keyframes loading {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  max-width: 300px;
+}
+
+label {
+  margin-bottom: 1rem;
+}
+
+form.submitting {
+  opacity: 0.6;
+  pointer-events: none;
+  position: relative;
+}
+
+form.submitting::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  height: 4px;
+  background: linear-gradient(90deg, #eee, #ddd, #eee);
+  background-size: 200% 100%;
+  animation: loading 1.5s infinite;
+}


### PR DESCRIPTION
## Summary
- Add demo invoice list and form with skeleton loading placeholders
- Display empty state messages and validation errors when data is missing or invalid
- Document how to view the demo interface

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6711da2f4832885d688fee3b1c3d5