### PR TITLE
docs: document environment variable setup for Vercel

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,4 @@
+# Place secrets here for local development
+# Example:
+DATABASE_URL=postgres://user:pass@localhost:5432/db
+SECRET_KEY=super-secret-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env.local
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # simple-invoice-website
+
 basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+## Environment Variables
+
+Store secrets for local development in `.env.local` and do not commit this file.
+
+1. Add your secret values to `.env.local`:
+
+   ```bash
+   DATABASE_URL=postgres://user:pass@localhost:5432/db
+   SECRET_KEY=super-secret-key
+   ```
+
+2. Configure the same variables in your Vercel project (via the dashboard or `vercel env`).
+
+3. Pull the Vercel configuration into a local `.env` file when developing:
+
+   ```bash
+   vercel env pull .env
+   ```
+
+At runtime, access the variables via `process.env`.
+Use the `NEXT_PUBLIC_` prefix for any values required on the client.


### PR DESCRIPTION
## Summary
- document how to use `.env.local` and `vercel env pull` for secrets
- add `.env.local.example` placeholder and ignore real env files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6714040988328b1a6a3ceb0083ea9