### PR TITLE
feat: add payment request integration

### DIFF
--- a/.well-known/apple-developer-merchantid-domain-association
+++ b/.well-known/apple-developer-merchantid-domain-association
@@ -1,0 +1,3 @@
+# Placeholder domain verification file for Apple Pay.
+# Replace with the exact file downloaded from the Apple Developer portal.
+{"merchantIdentifier":"merchant.com.example","domainName":"example.com","displayName":"Example Store"}

--- a/app/pay/page.tsx
+++ b/app/pay/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState, FormEvent } from 'react';
+import { loadStripe } from '@stripe/stripe-js';
+import {
+  Elements,
+  PaymentElement,
+  PaymentRequestButtonElement,
+  useElements,
+  useStripe,
+} from '@stripe/react-stripe-js';
+
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
+
+function CheckoutForm() {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [paymentRequest, setPaymentRequest] = useState<stripe.PaymentRequest | null>(null);
+
+  useEffect(() => {
+    if (!stripe) return;
+
+    const pr = stripe.paymentRequest({
+      country: 'US',
+      currency: 'usd',
+      total: { label: 'Invoice', amount: 1000 },
+      requestPayerName: true,
+      requestPayerEmail: true,
+    });
+
+    pr.canMakePayment().then(result => {
+      if (result) setPaymentRequest(pr);
+    });
+  }, [stripe]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!stripe || !elements) return;
+
+    const { error } = await stripe.confirmPayment({
+      elements,
+      confirmParams: {
+        return_url: `${window.location.origin}/pay/complete`,
+      },
+    });
+
+    if (error) {
+      console.error(error.message);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {paymentRequest && (
+        <PaymentRequestButtonElement options={{ paymentRequest }} />
+      )}
+      <PaymentElement />
+      <button type="submit" disabled={!stripe}>
+        Pay
+      </button>
+    </form>
+  );
+}
+
+export default function PayPage() {
+  const options = {
+    appearance: {},
+  } as const;
+
+  return (
+    <Elements stripe={stripePromise} options={options}>
+      <CheckoutForm />
+    </Elements>
+  );
+}
+


### PR DESCRIPTION
## Summary
- integrate Stripe Payment Element with Payment Request button
- add placeholder Apple Pay domain association file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b68dec25808328b4a5788c51d5eca2