### PR TITLE
feat: export receipts as zip

### DIFF
--- a/app/api/receipts/export/route.ts
+++ b/app/api/receipts/export/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import archiver from 'archiver';
+import { readdir } from 'fs/promises';
+import path from 'path';
+import { PassThrough } from 'stream';
+
+function nodeStreamToWeb(stream: NodeJS.ReadableStream): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      stream.on('data', (chunk) => controller.enqueue(typeof chunk === 'string' ? new TextEncoder().encode(chunk) : new Uint8Array(chunk)));
+      stream.on('end', () => controller.close());
+      stream.on('error', (err) => controller.error(err));
+    },
+    cancel() {
+      stream.destroy();
+    }
+  });
+}
+
+export async function GET() {
+  const receiptsDir = path.join(process.cwd(), 'storage', 'receipts');
+  const files = await readdir(receiptsDir);
+
+  const manifestLines: string[] = ['filename'];
+  const pass = new PassThrough();
+  const archive = archiver('zip', { zlib: { level: 9 } });
+  archive.pipe(pass);
+
+  for (const file of files) {
+    if (file.endsWith('.pdf')) {
+      const filePath = path.join(receiptsDir, file);
+      archive.file(filePath, { name: file });
+      manifestLines.push(file);
+    }
+  }
+
+  archive.append(manifestLines.join('\n'), { name: 'manifest.csv' });
+  archive.finalize();
+
+  const stream = nodeStreamToWeb(pass);
+
+  return new NextResponse(stream, {
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': 'attachment; filename="receipts.zip"'
+    }
+  });
+}

--- a/app/receipts/page.tsx
+++ b/app/receipts/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+export default function ReceiptsPage() {
+  const downloadAll = async () => {
+    const res = await fetch('/api/receipts/export');
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'receipts.zip';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div>
+      <h1>Receipts</h1>
+      <button onClick={downloadAll}>Download all receipts</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API route to zip stored receipt PDFs with a manifest CSV
- add receipts page with a "Download all receipts" button

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b68df1af4883289585ab7ccb536b57