### PR TITLE
feat: add internationalization with next-intl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # simple-invoice-website
-basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+Basic rent invoicing system that records payments and generates printable/PDF rent receipts.
+
+The app is built with Next.js and integrates [`next-intl`](https://next-intl.dev) for internationalization. All routes are prefixed with a locale (for example `/en` or `/es`) and UI strings are stored in translation files. A locale switcher component lets users toggle between languages while staying on the current page.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,0 +1,35 @@
+import {NextIntlClientProvider} from 'next-intl';
+import {notFound} from 'next/navigation';
+import {ReactNode} from 'react';
+import {locales} from '../../i18n';
+import LocaleSwitcher from '../../components/LocaleSwitcher';
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({locale}));
+}
+
+export default async function LocaleLayout({
+  children,
+  params: {locale}
+}: {
+  children: ReactNode;
+  params: {locale: string};
+}) {
+  let messages;
+  try {
+    messages = (await import(`../../messages/${locale}.json`)).default;
+  } catch (error) {
+    notFound();
+  }
+
+  return (
+    <html lang={locale}>
+      <body>
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <LocaleSwitcher />
+          {children}
+        </NextIntlClientProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,0 +1,11 @@
+import {useTranslations} from 'next-intl';
+
+export default function IndexPage() {
+  const t = useTranslations('Index');
+  return (
+    <main>
+      <h1>{t('title')}</h1>
+      <p>{t('description')}</p>
+    </main>
+  );
+}

--- a/components/LocaleSwitcher.tsx
+++ b/components/LocaleSwitcher.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import Link from 'next-intl/link';
+import {useLocale, useTranslations} from 'next-intl';
+import {usePathname} from 'next-intl/client';
+import {locales} from '../i18n';
+
+export default function LocaleSwitcher() {
+  const t = useTranslations('LocaleSwitcher');
+  const currentLocale = useLocale();
+  const pathname = usePathname();
+
+  return (
+    <div>
+      <span>{t('label')}: </span>
+      {locales.map((locale) => (
+        locale === currentLocale ? (
+          <span key={locale}>{locale.toUpperCase()}</span>
+        ) : (
+          <Link key={locale} href={pathname} locale={locale}>
+            {locale.toUpperCase()}
+          </Link>
+        )
+      ))}
+    </div>
+  );
+}

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,4 @@
+export const locales = ['en', 'es'] as const;
+export type Locale = (typeof locales)[number];
+export const defaultLocale: Locale = 'en';
+export const localePrefix = 'always';

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,9 @@
+{
+  "Index": {
+    "title": "Simple Invoice",
+    "description": "Basic rent invoicing system that records payments and generates printable/PDF rent receipts"
+  },
+  "LocaleSwitcher": {
+    "label": "Language"
+  }
+}

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,0 +1,9 @@
+{
+  "Index": {
+    "title": "Factura Simple",
+    "description": "Sistema básico de facturación de alquiler que registra pagos y genera recibos de alquiler imprimibles/PDF"
+  },
+  "LocaleSwitcher": {
+    "label": "Idioma"
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,12 @@
+import createMiddleware from 'next-intl/middleware';
+import {locales, defaultLocale, localePrefix} from './i18n';
+
+export default createMiddleware({
+  locales,
+  defaultLocale,
+  localePrefix
+});
+
+export const config = {
+  matcher: ['/', '/(en|es)/:path*']
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,10 @@
+import nextIntl from 'next-intl/plugin';
+
+const withNextIntl = nextIntl('./i18n.ts');
+
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {appDir: true}
+};
+
+export default withNextIntl(nextConfig);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "simple-invoice-website",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests defined\""
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-intl": "^3.8.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/react": "^18.0.0",
+    "@types/node": "^18.0.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- integrate next-intl and route-prefixed locales via `[locale]` layout and middleware
- move UI text into translation files and use `t()` helper
- add locale switcher component to toggle languages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b68dfb2778832883135d86a7c7b4be