### PR TITLE
feat: add localized email templates

### DIFF
--- a/emails/invoice.ts
+++ b/emails/invoice.ts
@@ -1,0 +1,21 @@
+const translations = {
+  en: {
+    subject: 'Invoice Ready',
+    body: (amount: number) => `Your invoice of $${amount} is ready.`,
+  },
+  es: {
+    subject: 'Factura Lista',
+    body: (amount: number) => `Tu factura de $${amount} está lista.`,
+  },
+} as const;
+
+export type Locale = keyof typeof translations;
+
+export function renderInvoiceEmail(locale: Locale, amount: number): string {
+  const t = translations[locale] ?? translations.en;
+  return `<h1>${t.subject}</h1><p>${t.body(amount)}</p>`;
+}
+
+export function getInvoiceSubject(locale: Locale): string {
+  return (translations[locale] ?? translations.en).subject;
+}

--- a/emails/welcome.ts
+++ b/emails/welcome.ts
@@ -1,0 +1,21 @@
+const translations = {
+  en: {
+    subject: 'Welcome',
+    body: 'Thanks for signing up!',
+  },
+  es: {
+    subject: 'Bienvenido',
+    body: '¡Gracias por registrarte!',
+  },
+} as const;
+
+export type Locale = keyof typeof translations;
+
+export function renderWelcomeEmail(locale: Locale): string {
+  const t = translations[locale] ?? translations.en;
+  return `<h1>${t.subject}</h1><p>${t.body}</p>`;
+}
+
+export function getWelcomeSubject(locale: Locale): string {
+  return (translations[locale] ?? translations.en).subject;
+}

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -1,0 +1,66 @@
+import { renderWelcomeEmail, getWelcomeSubject } from '../../emails/welcome';
+import { renderInvoiceEmail, getInvoiceSubject } from '../../emails/invoice';
+
+interface ResendEmailPayload {
+  from: string;
+  to: string;
+  subject: string;
+  html: string;
+}
+
+// Simple placeholder for the Resend client
+const resend = {
+  emails: {
+    send: async (payload: ResendEmailPayload) => payload,
+  },
+};
+
+export async function sendWelcomeEmail(
+  to: string,
+  locale: string,
+) {
+  const html = renderWelcomeEmail(locale as any);
+  const subject = getWelcomeSubject(locale as any);
+  return resend.emails.send({
+    from: 'no-reply@example.com',
+    to,
+    subject,
+    html,
+  });
+}
+
+export async function sendInvoiceEmail(
+  to: string,
+  locale: string,
+  amount: number,
+) {
+  const html = renderInvoiceEmail(locale as any, amount);
+  const subject = getInvoiceSubject(locale as any);
+  return resend.emails.send({
+    from: 'no-reply@example.com',
+    to,
+    subject,
+    html,
+  });
+}
+
+interface Tenant {
+  language?: string;
+}
+
+export async function sendWelcomeEmailForTenant(
+  to: string,
+  tenant: Tenant,
+) {
+  const locale = tenant.language ?? 'en';
+  return sendWelcomeEmail(to, locale);
+}
+
+export async function sendInvoiceEmailForTenant(
+  to: string,
+  amount: number,
+  tenant: Tenant,
+) {
+  const locale = tenant.language ?? 'en';
+  return sendInvoiceEmail(to, locale, amount);
+}


### PR DESCRIPTION
## Summary
- add locale-aware email senders
- translate invoice and welcome templates in English and Spanish
- select template based on tenant language

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b68dfef8088328af5a820d28c88261