### PR TITLE
Add currency field and block mixed-currency invoices

### DIFF
--- a/db/schema/properties.ts
+++ b/db/schema/properties.ts
@@ -1,0 +1,10 @@
+export interface InvoiceProperties {
+  /** Unique identifier for the invoice */
+  id: string;
+
+  /** Total amount for the invoice in the specified currency */
+  amount: number;
+
+  /** ISO 4217 currency code for the invoice */
+  currency: string;
+}

--- a/ui/invoice.html
+++ b/ui/invoice.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Invoice Form</title>
+  <script src="invoice.js" defer></script>
+  <style>
+    #fx-warning { color: red; display: none; }
+  </style>
+</head>
+<body>
+  <form id="invoice-form">
+    <label>Invoice Currency:
+      <select id="invoice-currency">
+        <option value="USD">USD</option>
+        <option value="EUR">EUR</option>
+        <option value="JPY">JPY</option>
+      </select>
+    </label>
+    <div id="items">
+      <div class="item">
+        <input type="number" class="amount" placeholder="Amount" />
+        <select class="currency">
+          <option value="USD">USD</option>
+          <option value="EUR">EUR</option>
+          <option value="JPY">JPY</option>
+        </select>
+      </div>
+    </div>
+    <button type="submit">Submit</button>
+  </form>
+  <p id="fx-warning">
+    Invoices with mixed currencies are not supported. Mixing currencies may expose you to foreign exchange risk.
+  </p>
+</body>
+</html>

--- a/ui/invoice.js
+++ b/ui/invoice.js
@@ -1,0 +1,35 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('invoice-form');
+  const invoiceCurrency = document.getElementById('invoice-currency');
+  const itemsContainer = document.getElementById('items');
+  const warning = document.getElementById('fx-warning');
+  const submitButton = form.querySelector('button[type="submit"]');
+
+  function checkCurrencies() {
+    const baseCurrency = invoiceCurrency.value;
+    const itemCurrencies = itemsContainer.querySelectorAll('.currency');
+    let mixed = false;
+    itemCurrencies.forEach(select => {
+      if (select.value !== baseCurrency) {
+        mixed = true;
+      }
+    });
+
+    if (mixed) {
+      warning.style.display = 'block';
+      submitButton.disabled = true;
+    } else {
+      warning.style.display = 'none';
+      submitButton.disabled = false;
+    }
+  }
+
+  invoiceCurrency.addEventListener('change', checkCurrencies);
+  itemsContainer.addEventListener('change', checkCurrencies);
+  form.addEventListener('submit', (e) => {
+    checkCurrencies();
+    if (submitButton.disabled) {
+      e.preventDefault();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add invoice schema with currency field
- block invoice submission when line items use different currencies and warn about FX risk

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b68dfff2908328a3bee3d587e8e998