### PR TITLE
Add PCI SAQ A runbook section with Stripe security references

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,13 @@
+# Runbook
+
+## PCI Compliance and SAQ A Scope
+
+This application relies on Stripe-hosted payment pages and Stripe.js to handle all cardholder interactions. As a result, it is eligible for PCI DSS Self-Assessment Questionnaire (SAQ) A.
+
+- No primary account numbers (PAN) are processed, stored, or transmitted by our servers.
+- Card data is entered only on Stripe-controlled interfaces and exchanged for tokens before reaching our backend.
+- Server-side operations use these tokens and non-sensitive metadata when creating charges or managing payments.
+
+For detailed guidance on maintaining this security posture and minimizing PCI scope, consult Stripe's security guides:
+
+- https://stripe.com/docs/security


### PR DESCRIPTION
## Summary
- create runbook detailing PCI DSS SAQ A scope
- state no PAN is ever handled by servers
- reference Stripe's security guide

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b68e0c297083288b5b65acd3b0dd8b