### PR TITLE
Implement cache revalidation and tagging for invoices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/app/api/invoices/route.js
+++ b/app/api/invoices/route.js
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
+
+let invoices = [{ id: 1, customer: 'Alice', amount: 100 }];
+
+export async function GET() {
+  return NextResponse.json(invoices);
+}
+
+export async function POST(req) {
+  const invoice = await req.json();
+  invoices.push(invoice);
+  revalidateTag('invoices');
+  return NextResponse.json({ ok: true });
+}

--- a/app/invoices/data.js
+++ b/app/invoices/data.js
@@ -1,0 +1,9 @@
+export async function getInvoices() {
+  const res = await fetch('http://localhost:3000/api/invoices', {
+    next: { revalidate: 60, tags: ['invoices'] }
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch invoices');
+  }
+  return res.json();
+}

--- a/app/invoices/page.js
+++ b/app/invoices/page.js
@@ -1,0 +1,17 @@
+import { getInvoices } from './data';
+
+export default async function InvoicesPage() {
+  const invoices = await getInvoices();
+  return (
+    <main>
+      <h1>Invoices</h1>
+      <ul>
+        {invoices.map((inv) => (
+          <li key={inv.id}>
+            {inv.customer}: ${inv.amount}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,0 +1,9 @@
+export const metadata = { title: 'Simple Invoice Website' };
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1>Home</h1>;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "simple-invoice-website",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js app with basic invoice page and API route
- use `fetch` with `revalidate` and `tags` in invoice data loader
- call `revalidateTag` after invoice mutations

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b68e0db19883289704f8bbc456f727