### PR TITLE
Add notification schema and settings UI

### DIFF
--- a/components/Notifications/index.tsx
+++ b/components/Notifications/index.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import type { Notification } from '../../db/schema/notifications';
+
+interface ListProps {
+  notifications: Notification[];
+  pageSize?: number;
+}
+
+// Bell icon that toggles the notification list
+export const NotificationBell: React.FC<ListProps> = ({ notifications, pageSize = 5 }) => {
+  const [open, setOpen] = useState(false);
+  const unread = notifications.filter((n) => !n.read).length;
+
+  return (
+    <div>
+      <button onClick={() => setOpen(!open)} aria-label="Notifications">
+        <span role="img" aria-label="bell">🔔</span>
+        {unread > 0 && <span>({unread})</span>}
+      </button>
+      {open && <NotificationList notifications={notifications} pageSize={pageSize} />}
+    </div>
+  );
+};
+
+// Paginated list of notifications
+export const NotificationList: React.FC<ListProps> = ({ notifications, pageSize = 5 }) => {
+  const [page, setPage] = useState(0);
+  const pages = Math.ceil(notifications.length / pageSize);
+  const start = page * pageSize;
+  const visible = notifications.slice(start, start + pageSize);
+
+  return (
+    <div>
+      <ul>
+        {visible.map((n) => (
+          <li key={n.id} style={{ fontWeight: n.read ? 'normal' : 'bold' }}>
+            {n.message}
+          </li>
+        ))}
+      </ul>
+      {pages > 1 && (
+        <div>
+          <button onClick={() => setPage((p) => Math.max(p - 1, 0))} disabled={page === 0}>
+            Prev
+          </button>
+          <span>
+            {page + 1} / {pages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(p + 1, pages - 1))}
+            disabled={page === pages - 1}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NotificationBell;

--- a/db/schema/notifications.ts
+++ b/db/schema/notifications.ts
@@ -1,0 +1,18 @@
+// Schema definition for notifications table
+// Each notification tracks whether it has been read by the user.
+
+export interface Notification {
+  id: number;
+  userId: number;
+  message: string;
+  /**
+   * Flag indicating whether the notification has been read.
+   * `false` means the user has not yet read the notification.
+   */
+  read: boolean;
+  createdAt: Date;
+}
+
+// In-memory placeholder list for notifications. In a real application this
+// would be backed by a persistent database table.
+export const notifications: Notification[] = [];

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+
+export default function Settings() {
+  const [email, setEmail] = useState(true);
+  const [sms, setSms] = useState(false);
+  const [push, setPush] = useState(true);
+
+  return (
+    <div>
+      <h1>Notification Settings</h1>
+      <label>
+        <input
+          type="checkbox"
+          checked={email}
+          onChange={(e) => setEmail(e.target.checked)}
+        />
+        Email
+      </label>
+      <br />
+      <label>
+        <input
+          type="checkbox"
+          checked={sms}
+          onChange={(e) => setSms(e.target.checked)}
+        />
+        SMS
+      </label>
+      <br />
+      <label>
+        <input
+          type="checkbox"
+          checked={push}
+          onChange={(e) => setPush(e.target.checked)}
+        />
+        Push
+      </label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- define basic Notification schema with read flag
- build notification bell with paginated list
- add settings page for email, SMS, and push notification toggles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b68df79fb083288003733b7e5085bf