### PR TITLE
feat: add branded Open Graph images

### DIFF
--- a/app/invoice/[id]/opengraph-image.tsx
+++ b/app/invoice/[id]/opengraph-image.tsx
@@ -1,0 +1,58 @@
+import { ImageResponse } from 'next/server';
+
+export const runtime = 'edge';
+export const contentType = 'image/png';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+async function getInvoice(id: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+  const res = await fetch(`${baseUrl}/api/invoices/${id}`);
+  if (!res.ok) {
+    throw new Error('Invoice fetch failed');
+  }
+  return res.json();
+}
+
+async function getProperty(id: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+  const res = await fetch(`${baseUrl}/api/properties/${id}`);
+  if (!res.ok) {
+    throw new Error('Property fetch failed');
+  }
+  return res.json();
+}
+
+export default async function Image({ params }: { params: { id: string } }) {
+  const invoice = await getInvoice(params.id);
+  const property = invoice.property ?? (await getProperty(invoice.propertyId));
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          backgroundColor: property.brandColor || '#1a1a1a',
+          color: '#fff',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          fontFamily: 'Arial, sans-serif',
+        }}
+      >
+        {property.logo && (
+          <img src={property.logo} width={128} height={128} alt="" />
+        )}
+        <div style={{ fontSize: 56, fontWeight: 700, marginTop: 32 }}>
+          Invoice #{invoice.number ?? params.id}
+        </div>
+        <div style={{ fontSize: 36 }}>{property.name}</div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/app/property/[id]/opengraph-image.tsx
+++ b/app/property/[id]/opengraph-image.tsx
@@ -1,0 +1,47 @@
+import { ImageResponse } from 'next/server';
+
+export const runtime = 'edge';
+export const contentType = 'image/png';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+async function getProperty(id: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+  const res = await fetch(`${baseUrl}/api/properties/${id}`);
+  if (!res.ok) {
+    throw new Error('Property fetch failed');
+  }
+  return res.json();
+}
+
+export default async function Image({ params }: { params: { id: string } }) {
+  const property = await getProperty(params.id);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          backgroundColor: property.brandColor || '#1a1a1a',
+          color: '#fff',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          fontFamily: 'Arial, sans-serif',
+        }}
+      >
+        {property.logo && (
+          <img src={property.logo} width={128} height={128} alt="" />
+        )}
+        <div style={{ fontSize: 64, fontWeight: 700, marginTop: 32 }}>
+          {property.name}
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}


### PR DESCRIPTION
## Summary
- generate property-branded Open Graph image for invoice routes
- add property-specific Open Graph image for property routes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b68e0ff1048328abc0852555fd55ab