### PR TITLE
Add Playwright end-to-end tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run tests
+        env:
+          APP_URL: ${{ secrets.APP_URL }}
+          TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+playwright-report/
+test-results/
+
+# Environment files
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # simple-invoice-website
+
 basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+## Testing
+
+End-to-end tests are written with [Playwright](https://playwright.dev/).
+
+### Running locally
+
+Install dependencies and browsers:
+
+```bash
+npm install
+npx playwright install chromium
+```
+
+Run tests (requires a running instance of the application):
+
+```bash
+APP_URL="http://localhost:3000" \
+TEST_USER_EMAIL="user@example.com" \
+TEST_USER_PASSWORD="password" \
+npm test
+```
+
+The tests cover:
+- logging in
+- viewing an invoice
+- completing a Stripe test payment using card `4242 4242 4242 4242`
+- viewing and printing the receipt
+
+### Continuous Integration
+
+GitHub Actions is configured to run the Playwright test suite on every push and pull request.
+Environment variables `APP_URL`, `TEST_USER_EMAIL`, and `TEST_USER_PASSWORD`
+must be provided via repository secrets for the workflow to execute the tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "simple-invoice-website",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "simple-invoice-website",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.55.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "simple-invoice-website",
+  "version": "1.0.0",
+  "description": "basic rent invoicing system that records payments and generates printable/PDF rent receipts",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.55.0"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests',
+  timeout: 30_000,
+  use: {
+    baseURL: process.env.APP_URL,
+    headless: true,
+  },
+});

--- a/tests/invoice.spec.ts
+++ b/tests/invoice.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+const baseUrl = process.env.APP_URL;
+const userEmail = process.env.TEST_USER_EMAIL;
+const userPassword = process.env.TEST_USER_PASSWORD;
+
+// Skip all tests if base URL or credentials are not provided
+const shouldSkip = !baseUrl || !userEmail || !userPassword;
+
+test.describe('Invoice payment flow', () => {
+  test.beforeEach(() => {
+    test.skip(shouldSkip, 'APP_URL, TEST_USER_EMAIL and TEST_USER_PASSWORD must be set');
+  });
+
+  test('login and navigate to dashboard', async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('input[name="email"]', userEmail!);
+    await page.fill('input[name="password"]', userPassword!);
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/.*dashboard/);
+  });
+
+  test('view invoice and complete Stripe test payment', async ({ page }) => {
+    await page.goto('/invoices/1');
+    await page.click('text=Pay with Card');
+    const stripe = page.frameLocator('iframe[name^="__privateStripeFrame"]');
+    await stripe.locator('input[placeholder="Card number"]').fill('4242 4242 4242 4242');
+    await stripe.locator('input[placeholder="MM / YY"]').fill('12 / 34');
+    await stripe.locator('input[placeholder="CVC"]').fill('123');
+    await stripe.locator('input[placeholder="ZIP"]').fill('12345');
+    await stripe.locator('text=Pay').click();
+    await expect(page).toHaveURL(/.*receipt/);
+  });
+
+  test('view and print receipt', async ({ page }) => {
+    await page.goto('/receipts/1');
+    const pdf = await page.pdf();
+    expect(pdf.byteLength).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- configure Playwright for end-to-end testing
- script login, invoice payment with Stripe test card, and receipt print flow
- add GitHub Actions workflow to run Playwright tests in CI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6714485348328885c61f03beb2bfd