### PR TITLE
Add Resend email client and templates

### DIFF
--- a/emails/DueReminderEmail.tsx
+++ b/emails/DueReminderEmail.tsx
@@ -1,0 +1,23 @@
+import { Html, Body, Container, Heading, Text } from '@react-email/components';
+
+interface DueReminderEmailProps {
+  name: string;
+  dueDate: string;
+  amount: string;
+}
+
+export function DueReminderEmail({ name, dueDate, amount }: DueReminderEmailProps) {
+  return (
+    <Html>
+      <Body>
+        <Container>
+          <Heading>Payment Reminder</Heading>
+          <Text>Hi {name},</Text>
+          <Text>This is a reminder that {amount} is due on {dueDate}.</Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export default DueReminderEmail;

--- a/emails/FailedPaymentEmail.tsx
+++ b/emails/FailedPaymentEmail.tsx
@@ -1,0 +1,22 @@
+import { Html, Body, Container, Heading, Text } from '@react-email/components';
+
+interface FailedPaymentEmailProps {
+  name: string;
+  date: string;
+}
+
+export function FailedPaymentEmail({ name, date }: FailedPaymentEmailProps) {
+  return (
+    <Html>
+      <Body>
+        <Container>
+          <Heading>Payment Failed</Heading>
+          <Text>Hi {name},</Text>
+          <Text>Your payment on {date} could not be processed.</Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export default FailedPaymentEmail;

--- a/emails/ReceiptEmail.tsx
+++ b/emails/ReceiptEmail.tsx
@@ -1,0 +1,23 @@
+import { Html, Body, Container, Heading, Text } from '@react-email/components';
+
+interface ReceiptEmailProps {
+  name: string;
+  amount: string;
+  date: string;
+}
+
+export function ReceiptEmail({ name, amount, date }: ReceiptEmailProps) {
+  return (
+    <Html>
+      <Body>
+        <Container>
+          <Heading>Payment Receipt</Heading>
+          <Text>Hi {name},</Text>
+          <Text>We received your payment of {amount} on {date}.</Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+export default ReceiptEmail;

--- a/lib/email/resend.ts
+++ b/lib/email/resend.ts
@@ -1,0 +1,33 @@
+import { Resend } from 'resend';
+import React from 'react';
+
+const resend = new Resend(process.env.RESEND_API_KEY || '');
+
+export async function sendEmail(options: {
+  from: string;
+  to: string;
+  subject: string;
+  react: React.ReactElement;
+}) {
+  try {
+    const data = await resend.emails.send(options);
+    console.log('Email sent', data);
+    return data;
+  } catch (error) {
+    console.error('Error sending email', error);
+    throw error;
+  }
+}
+
+export async function verifyDomain(domainId: string) {
+  try {
+    const data = await resend.domains.verify({ id: domainId });
+    console.log('Domain verified', data);
+    return data;
+  } catch (error) {
+    console.error('Domain verification failed', error);
+    throw error;
+  }
+}
+
+export default resend;


### PR DESCRIPTION
## Summary
- set up Resend API client with domain verification and send logging
- add React Email templates for payment reminders, receipts, and failed payments

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/simple-invoice-website/package.json')


------
https://chatgpt.com/codex/tasks/task_e_68b68df5dbd88328bc8dfa6ac57cf846