### PR TITLE
Add address formatting helper and phone input with validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # simple-invoice-website
-basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+Basic rent invoicing system that records payments and generates printable/PDF rent receipts.
+
+## Utilities
+
+- `lib/format/address.ts` uses [`address-formatter`](https://www.npmjs.com/package/address-formatter) to format address objects for display.
+- `components/PhoneField.tsx` integrates [`react-phone-number-input`](https://github.com/catamphetamine/react-phone-number-input) and validates numbers with [`libphonenumber-js`](https://github.com/catamphetamine/libphonenumber-js).

--- a/components/PhoneField.tsx
+++ b/components/PhoneField.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PhoneInput from 'react-phone-number-input';
+import { parsePhoneNumber } from 'libphonenumber-js';
+
+export interface PhoneFieldProps {
+  value?: string;
+  onChange: (value?: string) => void;
+}
+
+/**
+ * Phone input component with validation using libphonenumber.
+ */
+export const PhoneField: React.FC<PhoneFieldProps> = ({ value, onChange }) => {
+  const handleChange = (val?: string) => {
+    if (val) {
+      const parsed = parsePhoneNumber(val);
+      if (parsed && parsed.isValid()) {
+        onChange(parsed.number);
+      } else {
+        onChange(val);
+      }
+    } else {
+      onChange(val);
+    }
+  };
+
+  return (
+    <PhoneInput
+      international
+      defaultCountry="US"
+      value={value}
+      onChange={handleChange}
+    />
+  );
+};

--- a/lib/format/address.ts
+++ b/lib/format/address.ts
@@ -1,0 +1,20 @@
+import format from 'address-formatter';
+
+export interface Address {
+  house?: string;
+  road?: string;
+  suburb?: string;
+  city?: string;
+  county?: string;
+  state?: string;
+  postcode?: string;
+  country?: string;
+}
+
+/**
+ * Formats an address object into a human-readable multi-line string.
+ */
+export function formatAddress(address: Address): string {
+  const formatted = format(address, { output: 'array' }) as string[];
+  return formatted.join('\n');
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "simple-invoice-website",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "echo 'No tests defined'"
+  },
+  "dependencies": {
+    "address-formatter": "^1.3.3",
+    "libphonenumber-js": "^1.10.25",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-phone-number-input": "^3.2.14"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.31",
+    "@types/react-dom": "^18.2.14",
+    "typescript": "^5.3.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "outDir": "dist"
+  },
+  "include": ["lib", "components"]
+}


### PR DESCRIPTION
## Summary
- add address formatting helper leveraging address-formatter
- add PhoneField component using react-phone-number-input with libphonenumber validation
- document new utilities in README

## Testing
- `npm install` *(fails: Not Found - GET https://registry.npmjs.org/address-formatter)*
- `npm test`
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b68dfdba308328a57b8ccbdad28907