### PR TITLE
Implement lease lifecycle management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/lease/__init__.py
+++ b/lease/__init__.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional, Dict, Any
+
+
+class LeaseStatus(Enum):
+    """Possible states of a lease."""
+    PENDING = "pending"
+    ACTIVE = "active"
+    PAUSED = "paused"
+    TERMINATED = "terminated"
+
+
+@dataclass
+class LeaseEvent:
+    """Represents a lifecycle event for auditing purposes."""
+    action: str
+    timestamp: datetime
+    note: str = ""
+
+
+@dataclass
+class Lease:
+    """Represents a lease with lifecycle management."""
+    id: int
+    tenant: str
+    balance: float = 0.0
+    status: LeaseStatus = LeaseStatus.PENDING
+    activated_at: Optional[datetime] = None
+    paused_at: Optional[datetime] = None
+    terminated_at: Optional[datetime] = None
+    audit_log: List[LeaseEvent] = field(default_factory=list)
+
+    def _log(self, action: str, note: str = "") -> None:
+        self.audit_log.append(LeaseEvent(action=action, timestamp=datetime.utcnow(), note=note))
+
+    def activate(self) -> None:
+        """Activate the lease from pending or paused states."""
+        if self.status not in {LeaseStatus.PENDING, LeaseStatus.PAUSED}:
+            raise ValueError("Lease cannot be activated from current status")
+        self.status = LeaseStatus.ACTIVE
+        self.activated_at = datetime.utcnow()
+        self._log("activate")
+
+    def pause(self) -> None:
+        """Pause an active lease."""
+        if self.status != LeaseStatus.ACTIVE:
+            raise ValueError("Only active leases can be paused")
+        self.status = LeaseStatus.PAUSED
+        self.paused_at = datetime.utcnow()
+        self._log("pause")
+
+    def terminate(self) -> Dict[str, Any]:
+        """Terminate the lease and generate a final invoice."""
+        if self.status == LeaseStatus.TERMINATED:
+            raise ValueError("Lease already terminated")
+        self.status = LeaseStatus.TERMINATED
+        self.terminated_at = datetime.utcnow()
+        self._log("terminate")
+        return self._generate_final_invoice()
+
+    def _generate_final_invoice(self) -> Dict[str, Any]:
+        """Create a final invoice/receipt with remaining charges or credits."""
+        invoice = {
+            "lease_id": self.id,
+            "tenant": self.tenant,
+            "final_balance": self.balance,
+            "generated_at": datetime.utcnow(),
+        }
+        self._log("final_invoice", note=f"balance={self.balance}")
+        return invoice

--- a/tests/test_lease.py
+++ b/tests/test_lease.py
@@ -1,0 +1,41 @@
+import sys
+import pathlib
+import pytest
+
+# Ensure project root is on sys.path
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from lease import Lease, LeaseStatus
+
+
+def test_activation_and_pause():
+    lease = Lease(id=1, tenant="Alice")
+    lease.activate()
+    assert lease.status == LeaseStatus.ACTIVE
+    assert lease.activated_at is not None
+
+    lease.pause()
+    assert lease.status == LeaseStatus.PAUSED
+    assert lease.paused_at is not None
+
+
+def test_termination_generates_invoice_and_logs():
+    lease = Lease(id=2, tenant="Bob", balance=100.0)
+    lease.activate()
+    invoice = lease.terminate()
+
+    assert lease.status == LeaseStatus.TERMINATED
+    assert lease.terminated_at is not None
+    assert invoice["final_balance"] == 100.0
+    actions = [event.action for event in lease.audit_log]
+    assert actions[-2:] == ["terminate", "final_invoice"]
+
+
+def test_invalid_transitions():
+    lease = Lease(id=3, tenant="Charlie")
+    with pytest.raises(ValueError):
+        lease.pause()
+    lease.activate()
+    lease.terminate()
+    with pytest.raises(ValueError):
+        lease.activate()


### PR DESCRIPTION
## Summary
- add Lease model with status transitions and timestamps
- support activating, pausing, terminating leases and final invoice generation
- log lease lifecycle events and add tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b69c7454b48328bee22c015a822a2a