### PR TITLE
Add proration engine and mid-month move-in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/invoice/invoice_generation.py
+++ b/invoice/invoice_generation.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal, ROUND_HALF_UP
+
+from .models import Lease
+from .proration import ProrationService
+
+
+def generate_invoice(lease: Lease, period_start: date, period_end: date) -> Decimal:
+    """Generate invoice amount for the given period."""
+    if period_start > period_end:
+        raise ValueError("period start must be on or before period end")
+
+    amount: Decimal
+
+    if lease.start_date > period_start:
+        # Move-in within the period
+        amount = ProrationService.prorate(
+            lease.monthly_rent, lease.start_date, period_end, lease.proration_rule
+        )
+    elif lease.end_date is not None and lease.end_date < period_end:
+        # Move-out within the period
+        amount = ProrationService.prorate(
+            lease.monthly_rent, period_start, lease.end_date, lease.proration_rule
+        )
+    else:
+        amount = lease.monthly_rent
+
+    return amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)

--- a/invoice/models.py
+++ b/invoice/models.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from enum import Enum
+
+
+class ProrationRule(Enum):
+    """Rules for prorating rent."""
+    ACTUAL_ACTUAL = "actual_actual"
+    THIRTY_360 = "30_360"
+
+
+@dataclass
+class Lease:
+    start_date: date
+    end_date: date | None
+    monthly_rent: Decimal
+    proration_rule: ProrationRule = ProrationRule.ACTUAL_ACTUAL

--- a/invoice/proration.py
+++ b/invoice/proration.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal, ROUND_HALF_UP
+import calendar
+
+from .models import ProrationRule
+
+
+class ProrationService:
+    """Service to prorate monthly rent for partial periods."""
+
+    @staticmethod
+    def prorate(monthly_rent: Decimal, start: date, end: date, rule: ProrationRule) -> Decimal:
+        if start > end:
+            raise ValueError("start date must be on or before end date")
+
+        if rule == ProrationRule.ACTUAL_ACTUAL:
+            days_in_month = calendar.monthrange(start.year, start.month)[1]
+            days = (end - start).days + 1
+            daily_rate = monthly_rent / Decimal(days_in_month)
+            amount = daily_rate * days
+        elif rule == ProrationRule.THIRTY_360:
+            # Treat all months as 30 days
+            days = 30 - (start.day - 1)
+            daily_rate = monthly_rent / Decimal(30)
+            amount = daily_rate * days
+        else:
+            raise ValueError(f"Unsupported proration rule: {rule}")
+
+        return amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)

--- a/tests/test_proration.py
+++ b/tests/test_proration.py
@@ -1,0 +1,27 @@
+from datetime import date
+from decimal import Decimal
+
+from invoice.models import Lease, ProrationRule
+from invoice.invoice_generation import generate_invoice
+
+
+def test_mid_month_move_in_actual_actual():
+    lease = Lease(
+        start_date=date(2023, 7, 10),
+        end_date=None,
+        monthly_rent=Decimal("1000.00"),
+        proration_rule=ProrationRule.ACTUAL_ACTUAL,
+    )
+    amount = generate_invoice(lease, date(2023, 7, 1), date(2023, 7, 31))
+    assert amount == Decimal("709.68")
+
+
+def test_mid_month_move_in_30_360():
+    lease = Lease(
+        start_date=date(2023, 7, 10),
+        end_date=None,
+        monthly_rent=Decimal("1000.00"),
+        proration_rule=ProrationRule.THIRTY_360,
+    )
+    amount = generate_invoice(lease, date(2023, 7, 1), date(2023, 7, 31))
+    assert amount == Decimal("700.00")


### PR DESCRIPTION
## Summary
- implement `ProrationService` supporting Actual/Actual and 30/360 methods
- add `proration_rule` field to `Lease` model
- integrate proration into invoice generation for partial periods
- add unit tests for mid-month move-in invoices using both proration rules

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69c724844832899e2679c0cb88524