### PR TITLE
Add idempotent invoice migration with rollback docs

### DIFF
--- a/docs/migration-map-invoices.md
+++ b/docs/migration-map-invoices.md
@@ -1,0 +1,46 @@
+# Invoice Migration to Leases and Units
+
+This migration maps existing `invoices` records to the new `leases` and `units` tables. It is safe to run multiple times.
+
+## Running the Migration
+
+```bash
+psql "$DATABASE_URL" -f migrations/20230902_map_invoices_to_leases_units.sql
+```
+
+## Rollback
+
+1. Remove invoice references:
+   ```sql
+   UPDATE invoices SET lease_id = NULL, unit_id = NULL;
+   ```
+2. Delete leases and units with no references:
+   ```sql
+   DELETE FROM leases  l WHERE NOT EXISTS (SELECT 1 FROM invoices i WHERE i.lease_id = l.id);
+   DELETE FROM units   u WHERE NOT EXISTS (SELECT 1 FROM leases  l WHERE l.unit_id = u.id);
+   ```
+
+## Re-running
+The script uses `NOT EXISTS` checks and updates only when values differ, allowing it to be executed multiple times without side effects.
+
+## Staging Verification
+
+After running the migration in staging:
+
+1. Ensure all invoices have references:
+   ```sql
+   SELECT COUNT(*) FROM invoices WHERE lease_id IS NULL OR unit_id IS NULL;
+   ```
+2. Check for duplicate leases/units:
+   ```sql
+   SELECT tenant_id, unit_id, COUNT(*) FROM leases GROUP BY 1,2 HAVING COUNT(*) > 1;
+   SELECT property_id, number, COUNT(*) FROM units GROUP BY 1,2 HAVING COUNT(*) > 1;
+   ```
+
+## Deployment Execution
+Include the following step in the deployment process:
+
+```bash
+psql "$DATABASE_URL" -f migrations/20230902_map_invoices_to_leases_units.sql
+```
+

--- a/migrations/20230902_map_invoices_to_leases_units.sql
+++ b/migrations/20230902_map_invoices_to_leases_units.sql
@@ -1,0 +1,46 @@
+-- Migration: Map old invoice records to new leases and units
+-- This script is idempotent and can be run multiple times safely.
+-- It inserts missing units and leases based on existing invoice data
+-- and updates invoices to reference the newly created records.
+
+BEGIN;
+
+-- Insert units derived from invoice property/unit numbers
+INSERT INTO units(id, property_id, number)
+SELECT DISTINCT
+       md5(CAST(property_id AS text) || '-' || unit_number) AS id,
+       property_id,
+       unit_number
+FROM invoices i
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM units u
+    WHERE u.property_id = i.property_id AND u.number = i.unit_number
+);
+
+-- Insert leases linking tenants to units
+INSERT INTO leases(id, tenant_id, unit_id)
+SELECT DISTINCT
+       md5(CAST(i.tenant_id AS text) || '-' || u.id) AS id,
+       i.tenant_id,
+       u.id AS unit_id
+FROM invoices i
+JOIN units u ON u.property_id = i.property_id AND u.number = i.unit_number
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM leases l
+    WHERE l.tenant_id = i.tenant_id AND l.unit_id = u.id
+);
+
+-- Update invoices with lease and unit references
+UPDATE invoices i
+SET lease_id = l.id,
+    unit_id = u.id
+FROM leases l
+JOIN units u ON l.unit_id = u.id
+WHERE i.tenant_id = l.tenant_id
+  AND i.property_id = u.property_id
+  AND i.unit_number = u.number
+  AND (i.lease_id IS DISTINCT FROM l.id OR i.unit_id IS DISTINCT FROM u.id);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add idempotent SQL migration to map invoices to new leases and units
- document rollback, re-run safety, staging verification, and deployment commands

## Testing
- `psql --version`
- `psql -d postgres -f migrations/20230902_map_invoices_to_leases_units.sql` *(fails: Is the server running locally and accepting connections on that socket?)*

------
https://chatgpt.com/codex/tasks/task_e_68b69c751e5083288e9e09a2af74be97