### PR TITLE
feat: add Dropbox Sign embedded flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -1,0 +1,24 @@
+const { setProvider } = require('./src/organizationSettings');
+const { launchSigning, saveSignedDocument } = require('./src/signingFlow');
+const fs = require('fs');
+
+async function demo() {
+  // Example: configure to use Dropbox Sign
+  setProvider('dropbox');
+
+  // Launch signing
+  const signUrl = 'https://example.com/dropbox-sign-url';
+  try {
+    await launchSigning(signUrl, { clientId: 'YOUR_CLIENT_ID' });
+    console.log('Signing complete');
+
+    // simulate saving signed document
+    const dummyBuffer = Buffer.from('signed-document');
+    const savedPath = saveSignedDocument('lease.pdf', dummyBuffer);
+    console.log('Saved to', savedPath);
+  } catch (err) {
+    console.error('Signing failed:', err.message);
+  }
+}
+
+demo();

--- a/organizationSettings.json
+++ b/organizationSettings.json
@@ -1,0 +1,3 @@
+{
+  "provider": "default"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,65 @@
+{
+  "name": "simple-invoice-website",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "simple-invoice-website",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "hellosign-embedded": "^2.12.3"
+      }
+    },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/hellosign-embedded": {
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/hellosign-embedded/-/hellosign-embedded-2.12.3.tgz",
+      "integrity": "sha512-HHPhGQT6dgVy6nm2xeKNiysb3XE0anjYWPXgjoxWL9vpbxW6bKjkWJQA0eNNR/+jdReTenArnLHyXZm8l0BbgA==",
+      "license": "MIT",
+      "dependencies": {
+        "common-tags": "^1.8.0",
+        "debug": "^4.1.1",
+        "tiny-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "simple-invoice-website",
+  "version": "1.0.0",
+  "description": "basic rent invoicing system that records payments and generates printable/PDF rent receipts",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "hellosign-embedded": "^2.12.3"
+  }
+}

--- a/src/leaseLibrary.js
+++ b/src/leaseLibrary.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const libraryDir = path.join(__dirname, '..', 'lease-library');
+
+function ensureDir() {
+  if (!fs.existsSync(libraryDir)) {
+    fs.mkdirSync(libraryDir);
+  }
+}
+
+function saveDocument(filename, buffer) {
+  ensureDir();
+  const filePath = path.join(libraryDir, filename);
+  fs.writeFileSync(filePath, buffer);
+  return filePath;
+}
+
+module.exports = {
+  saveDocument,
+};

--- a/src/organizationSettings.js
+++ b/src/organizationSettings.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+const settingsPath = path.join(__dirname, '..', 'organizationSettings.json');
+
+function readSettings() {
+  try {
+    const raw = fs.readFileSync(settingsPath, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    return { provider: 'default' };
+  }
+}
+
+function writeSettings(settings) {
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+}
+
+function getProvider() {
+  const settings = readSettings();
+  return settings.provider || 'default';
+}
+
+function setProvider(provider) {
+  const settings = readSettings();
+  settings.provider = provider;
+  writeSettings(settings);
+}
+
+module.exports = {
+  getProvider,
+  setProvider,
+};

--- a/src/providers/default.js
+++ b/src/providers/default.js
@@ -1,0 +1,14 @@
+const { saveDocument } = require('../leaseLibrary');
+
+async function launch() {
+  throw new Error('No signing provider configured');
+}
+
+function saveSignedDocument(filename, fileBuffer) {
+  return saveDocument(filename, fileBuffer);
+}
+
+module.exports = {
+  launch,
+  saveSignedDocument,
+};

--- a/src/providers/dropbox.js
+++ b/src/providers/dropbox.js
@@ -1,0 +1,28 @@
+const HelloSign = require('hellosign-embedded');
+const { saveDocument } = require('../leaseLibrary');
+
+async function launch(signUrl, opts = {}) {
+  const client = new HelloSign(opts); // opts may include clientId
+  return new Promise((resolve, reject) => {
+    client.open(signUrl, {
+      debug: opts.debug || false,
+      allowCancel: true,
+      // Callback when signing is complete
+      messageListener: event => {
+        if (event && event.eventName === 'signature_request_signed') {
+          resolve(event);
+        }
+      }
+    });
+  });
+}
+
+// Save signed document to lease library
+function saveSignedDocument(filename, fileBuffer) {
+  return saveDocument(filename, fileBuffer);
+}
+
+module.exports = {
+  launch,
+  saveSignedDocument,
+};

--- a/src/signingFlow.js
+++ b/src/signingFlow.js
@@ -1,0 +1,38 @@
+const { getProvider } = require('./organizationSettings');
+const dropbox = require('./providers/dropbox');
+const defaultProvider = require('./providers/default');
+
+/**
+ * Launch the signing flow based on configured provider.
+ * @param {string} signUrl URL to initiate signing.
+ * @param {Object} options Options for provider clients.
+ */
+async function launchSigning(signUrl, options = {}) {
+  const provider = getProvider();
+  switch (provider) {
+    case 'dropbox':
+      return dropbox.launch(signUrl, options);
+    default:
+      return defaultProvider.launch(signUrl, options);
+  }
+}
+
+/**
+ * Persist a signed document to the lease library regardless of provider.
+ * @param {string} filename Document filename.
+ * @param {Buffer} buffer Document binary contents.
+ */
+function saveSignedDocument(filename, buffer) {
+  const provider = getProvider();
+  switch (provider) {
+    case 'dropbox':
+      return dropbox.saveSignedDocument(filename, buffer);
+    default:
+      return defaultProvider.saveSignedDocument(filename, buffer);
+  }
+}
+
+module.exports = {
+  launchSigning,
+  saveSignedDocument,
+};


### PR DESCRIPTION
## Summary
- add organization signing provider setting
- integrate Dropbox Sign via hellosign-embedded
- save signed documents to lease library and branch flows per provider

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b69c780dc88328a78f51e09be8e20c