### PR TITLE
Add Stripe subscription management

### DIFF
--- a/stripe_subscription.py
+++ b/stripe_subscription.py
@@ -1,0 +1,83 @@
+import os
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import stripe
+
+stripe.api_key = os.environ.get("STRIPE_API_KEY", "")
+
+@dataclass
+class Lease:
+    """Represents a lease in the application."""
+    id: int
+    monthly_rent: int  # dollars
+    stripe_customer_id: str
+    stripe_subscription_id: Optional[str] = None
+    status: str = "pending"
+
+
+def create_subscription_for_lease(lease: Lease):
+    """Create a Stripe subscription for the given lease.
+
+    Parameters
+    ----------
+    lease: Lease
+        Lease to attach subscription to. Assumes `stripe_customer_id` is set.
+
+    Returns
+    -------
+    stripe.Subscription
+        The created subscription object.
+    """
+    subscription = stripe.Subscription.create(
+        customer=lease.stripe_customer_id,
+        items=[{
+            "price_data": {
+                "currency": "usd",
+                "unit_amount": lease.monthly_rent * 100,
+                "recurring": {"interval": "month"},
+                "product_data": {"name": f"Lease {lease.id} Rent"},
+            }
+        }],
+    )
+    lease.stripe_subscription_id = subscription.id
+    return subscription
+
+
+def reconcile_invoices(lease: Lease):
+    """Retrieve Stripe invoices for a lease subscription.
+
+    Returns a list of invoices for further reconciliation with the app's
+    invoice records.
+    """
+    if not lease.stripe_subscription_id:
+        raise ValueError("Lease has no subscription ID")
+    return stripe.Invoice.list(subscription=lease.stripe_subscription_id)
+
+
+def refresh_subscription_status(lease: Lease):
+    """Refresh the subscription status from Stripe and update the lease."""
+    if not lease.stripe_subscription_id:
+        raise ValueError("Lease has no subscription ID")
+    subscription = stripe.Subscription.retrieve(lease.stripe_subscription_id)
+    lease.status = subscription.status
+    return subscription.status
+
+
+def handle_billing_event(event: stripe.Event, update_invoice: Callable):
+    """React to Stripe billing events to keep app invoices up-to-date.
+
+    Parameters
+    ----------
+    event: stripe.Event
+        The event received from Stripe's webhook.
+    update_invoice: Callable
+        Callback that updates an invoice in the application. Should accept the
+        stripe invoice object and an optional `cancelled` flag.
+    """
+    data = event.data.object
+
+    if event.type in {"invoice.paid", "invoice.payment_failed"}:
+        update_invoice(data)
+    elif event.type == "customer.subscription.deleted":
+        update_invoice(data, cancelled=True)

--- a/tests/test_stripe_subscription.py
+++ b/tests/test_stripe_subscription.py
@@ -1,0 +1,34 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from unittest.mock import MagicMock, patch
+
+from stripe_subscription import (
+    Lease,
+    create_subscription_for_lease,
+    refresh_subscription_status,
+)
+
+
+def test_create_subscription_links_id():
+    lease = Lease(id=1, monthly_rent=1000, stripe_customer_id="cus_123")
+    with patch("stripe_subscription.stripe.Subscription.create") as create:
+        create.return_value = MagicMock(id="sub_123")
+        sub = create_subscription_for_lease(lease)
+        create.assert_called_once()
+        assert lease.stripe_subscription_id == "sub_123"
+        assert sub.id == "sub_123"
+
+
+def test_refresh_subscription_status():
+    lease = Lease(
+        id=1,
+        monthly_rent=1000,
+        stripe_customer_id="cus_123",
+        stripe_subscription_id="sub_456",
+    )
+    with patch("stripe_subscription.stripe.Subscription.retrieve") as retrieve:
+        retrieve.return_value = MagicMock(status="active")
+        status = refresh_subscription_status(lease)
+        retrieve.assert_called_once_with("sub_456")
+        assert status == "active"
+        assert lease.status == "active"


### PR DESCRIPTION
## Summary
- create Stripe subscriptions for leases and capture IDs
- expose helpers to refresh subscription status and process billing events
- test subscription creation and status refresh with mocks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69ca26ffc8328a821eaf393be38f2