### PR TITLE
Implement retry communication scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # simple-invoice-website
-basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+Basic rent invoicing system that records payments and generates printable/PDF rent receipts.
+
+## Payment retry communication
+
+The codebase now includes simple helpers for scheduling retry emails/SMS when a payment fails.
+A configurable cadence (default `0/3/7` days) can be adjusted per organization via
+an in-memory admin interface. When payment succeeds, retries are cancelled and the invoice is
+marked complete. Every action taken is stored on the invoice's communication history.

--- a/cadence_admin.py
+++ b/cadence_admin.py
@@ -1,0 +1,21 @@
+"""Simple in-memory admin interface for managing retry cadences."""
+
+# default cadence uses immediate, 3 days and 7 days after the failed payment
+_cadence_schedule = {}
+_default_schedule = [0, 3, 7]
+
+def get_cadence(organization_id):
+    """Return the retry schedule for an organization."""
+    return _cadence_schedule.get(organization_id, list(_default_schedule))
+
+def set_cadence(organization_id, schedule):
+    """Update the retry schedule for an organization.
+
+    Parameters
+    ----------
+    organization_id: str
+        identifier for the organization whose schedule is adjusted.
+    schedule: iterable
+        collection of integers representing days after failure when retries occur.
+    """
+    _cadence_schedule[organization_id] = list(schedule)

--- a/invoice.py
+++ b/invoice.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+class Invoice:
+    """Represents a simple invoice and its communication history."""
+
+    def __init__(self, invoice_id, organization_id, amount_due):
+        self.invoice_id = invoice_id
+        self.organization_id = organization_id
+        self.amount_due = amount_due
+        self.paid = False
+        # list of dictionaries recording communications related to this invoice
+        self.communication_history = []
+        # scheduled retry datetimes for future communications
+        self.scheduled_retries = []
+
+    def record_communication(self, channel, status, timestamp=None, info=None):
+        """Track a communication event for the invoice.
+
+        Parameters
+        ----------
+        channel: str
+            e.g. "email" or "sms" or "schedule".
+        status: str
+            description such as "sent", "queued" or "success".
+        timestamp: datetime, optional
+            when the event occurred. Defaults to utcnow.
+        info: str, optional
+            additional details to store with the event.
+        """
+        timestamp = timestamp or datetime.utcnow()
+        event = {"time": timestamp, "channel": channel, "status": status}
+        if info:
+            event["info"] = info
+        self.communication_history.append(event)

--- a/retry_scheduler.py
+++ b/retry_scheduler.py
@@ -1,0 +1,39 @@
+"""Utilities for scheduling payment retry communications."""
+
+from datetime import datetime, timedelta
+from cadence_admin import get_cadence
+
+
+def schedule_retries(invoice, failure_date=None, schedule=None):
+    """Populate an invoice with scheduled retry communications.
+
+    Parameters
+    ----------
+    invoice: Invoice
+        target invoice object.
+    failure_date: datetime, optional
+        date the payment failed. Defaults to now.
+    schedule: list[int], optional
+        explicit schedule overriding organization cadence.
+    """
+    failure_date = failure_date or datetime.utcnow()
+    schedule = schedule or get_cadence(invoice.organization_id)
+    invoice.scheduled_retries = []
+    for days in schedule:
+        retry_time = failure_date + timedelta(days=days)
+        invoice.scheduled_retries.append(retry_time)
+        invoice.record_communication(
+            channel="schedule",
+            status="queued",
+            timestamp=retry_time,
+            info=f"Retry at {retry_time.isoformat()}"
+        )
+    return invoice.scheduled_retries
+
+
+def mark_payment_success(invoice, timestamp=None):
+    """Mark invoice as paid and clear outstanding retries."""
+    timestamp = timestamp or datetime.utcnow()
+    invoice.paid = True
+    invoice.scheduled_retries.clear()
+    invoice.record_communication("payment", "success", timestamp)


### PR DESCRIPTION
## Summary
- add `Invoice` model with communication history
- provide admin helpers for per-organization retry cadence
- schedule retries and mark invoices paid when payment succeeds

## Testing
- `python -m py_compile invoice.py cadence_admin.py retry_scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_68b69ca312f08328b7e610609108b7f0