### PR TITLE
Track payment decline codes and dunning metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # simple-invoice-website
-basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+Basic rent invoicing system that records payments and generates printable/PDF rent receipts.
+
+## Payment recovery utilities
+
+The project now includes simple tooling to track failed payment attempts and analyse
+recovery performance:
+
+- `payment_processor.py` records each payment attempt, capturing the `decline_code`,
+  retry number and timestamp.
+- `dashboard.py` reports the recovery rate by decline reason using the stored data.
+- `dunning_strategy.py` offers naive dunning recommendations based on observed
+  recovery rates.
+
+Tests demonstrate the tracking and reporting workflow.

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,46 @@
+from collections import defaultdict
+
+from database import get_connection, init_db
+
+
+def recovery_rate_by_decline_reason(db_path=None) -> dict[str, float]:
+    """Compute recovery rate by decline code."""
+    init_db(db_path)
+    if db_path is None:
+        from database import DB_PATH
+        db_path = DB_PATH
+
+    with get_connection(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT payment_id, attempt_no, status, decline_code
+            FROM payment_attempts
+            ORDER BY payment_id, attempt_no
+            """
+        ).fetchall()
+
+    # Determine first decline per payment and whether it later succeeded
+    first_decline: dict[str, str] = {}
+    success_after_decline: defaultdict[str, set[str]] = defaultdict(set)
+    total_failures: defaultdict[str, set[str]] = defaultdict(set)
+
+    for payment_id, attempt_no, status, decline_code in rows:
+        if payment_id not in first_decline and status == "failed" and decline_code:
+            first_decline[payment_id] = decline_code
+            total_failures[decline_code].add(payment_id)
+        if status == "succeeded" and payment_id in first_decline:
+            code = first_decline[payment_id]
+            success_after_decline[code].add(payment_id)
+
+    rates: dict[str, float] = {}
+    for code, payments in total_failures.items():
+        recovered = len(success_after_decline.get(code, set()))
+        rate = recovered / len(payments) if payments else 0.0
+        rates[code] = rate
+    return rates
+
+
+if __name__ == "__main__":
+    rates = recovery_rate_by_decline_reason()
+    for code, rate in rates.items():
+        print(f"Decline code {code}: recovery rate {rate:.2%}")

--- a/database.py
+++ b/database.py
@@ -1,0 +1,36 @@
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+
+DB_PATH = Path(__file__).with_name("payments.db")
+
+
+def init_db(path: Path = DB_PATH) -> None:
+    """Initialize the payments database with the required table."""
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS payment_attempts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                payment_id TEXT NOT NULL,
+                attempt_no INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                decline_code TEXT,
+                timestamp TEXT NOT NULL
+            )
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@contextmanager
+def get_connection(path: Path = DB_PATH):
+    """Context manager that yields a SQLite connection."""
+    conn = sqlite3.connect(path)
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/dunning_strategy.py
+++ b/dunning_strategy.py
@@ -1,0 +1,22 @@
+from dashboard import recovery_rate_by_decline_reason
+
+
+def recommend_actions(db_path=None) -> dict[str, str]:
+    """Return simple dunning recommendations based on recovery rates."""
+    rates = recovery_rate_by_decline_reason(db_path)
+    recommendations: dict[str, str] = {}
+    for code, rate in rates.items():
+        if rate <= 0.2:
+            action = "Escalate after first retry"
+        elif rate <= 0.5:
+            action = "Retry twice before escalation"
+        else:
+            action = "Allow multiple retries"
+        recommendations[code] = action
+    return recommendations
+
+
+if __name__ == "__main__":
+    recs = recommend_actions()
+    for code, action in recs.items():
+        print(f"Decline code {code}: {action}")

--- a/payment_processor.py
+++ b/payment_processor.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from database import get_connection, init_db
+
+
+@dataclass
+class PaymentResult:
+    payment_id: str
+    attempt_no: int
+    status: str
+    decline_code: Optional[str]
+    timestamp: str
+
+
+class PaymentProcessor:
+    """Record payment attempts and their outcomes."""
+
+    def __init__(self, db_path=None):
+        if db_path:
+            init_db(db_path)
+            self.db_path = db_path
+        else:
+            init_db()
+            from database import DB_PATH
+            self.db_path = DB_PATH
+
+    def record_attempt(
+        self, payment_id: str, attempt_no: int, status: str, decline_code: Optional[str] = None
+    ) -> PaymentResult:
+        """Persist a payment attempt in the database."""
+        timestamp = datetime.utcnow().isoformat()
+        with get_connection(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO payment_attempts(payment_id, attempt_no, status, decline_code, timestamp)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (payment_id, attempt_no, status, decline_code, timestamp),
+            )
+            conn.commit()
+        return PaymentResult(payment_id, attempt_no, status, decline_code, timestamp)
+
+    def attempt_payment(
+        self,
+        payment_id: str,
+        simulate_results: list[tuple[str, Optional[str]]],
+    ) -> list[PaymentResult]:
+        """Simulate payment processing and record each attempt.
+
+        Args:
+            payment_id: Identifier for the payment.
+            simulate_results: A list of tuples in the form (status, decline_code).
+                Each tuple represents the outcome of an attempt. The first tuple is
+                for attempt_no=1, the next for attempt_no=2, etc. When status is
+                'succeeded', decline_code should be None.
+
+        Returns:
+            List of PaymentResult entries recorded.
+        """
+        results: list[PaymentResult] = []
+        for attempt_no, (status, decline_code) in enumerate(simulate_results, start=1):
+            result = self.record_attempt(
+                payment_id, attempt_no, status, decline_code
+            )
+            results.append(result)
+            if status == "succeeded":
+                break
+        return results

--- a/tests/test_payment_processor.py
+++ b/tests/test_payment_processor.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dashboard import recovery_rate_by_decline_reason
+from dunning_strategy import recommend_actions
+from payment_processor import PaymentProcessor
+from database import init_db
+
+
+def test_record_and_dashboard(tmp_path: Path):
+    db_file = tmp_path / "test.db"
+    init_db(db_file)
+    processor = PaymentProcessor(db_file)
+
+    # Simulate a payment that fails then succeeds
+    processor.attempt_payment(
+        "pay_1", [("failed", "insufficient_funds"), ("succeeded", None)]
+    )
+
+    # Simulate a payment that fails twice and never recovers
+    processor.attempt_payment(
+        "pay_2",
+        [
+            ("failed", "insufficient_funds"),
+            ("failed", "insufficient_funds"),
+        ],
+    )
+
+    rates = recovery_rate_by_decline_reason(db_file)
+    assert rates["insufficient_funds"] == 0.5
+
+    recs = recommend_actions(db_file)
+    assert recs["insufficient_funds"] == "Retry twice before escalation"


### PR DESCRIPTION
## Summary
- log each payment attempt with decline code, status, and timestamp
- compute recovery rate by decline reason and recommend dunning actions
- document new payment recovery utilities and add tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b69ca4e6c883289215f7df81a1964d