### PR TITLE
Enable pg_trgm extension and trigram search

### DIFF
--- a/db/migrate/20240801000000_enable_pg_trgm.sql
+++ b/db/migrate/20240801000000_enable_pg_trgm.sql
@@ -1,0 +1,4 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS index_tenants_on_name_trgm ON tenants USING gin (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS index_units_on_identifier_trgm ON units USING gin (identifier gin_trgm_ops);

--- a/search_queries.sql
+++ b/search_queries.sql
@@ -1,0 +1,12 @@
+-- Search tenants by name or units by identifier using LIKE and trigram similarity.
+-- Replace $1 with the search term.
+
+-- Tenant search
+SELECT * FROM tenants
+WHERE name ILIKE '%' || $1 || '%' OR similarity(name, $1) > 0.1
+ORDER BY similarity(name, $1) DESC;
+
+-- Unit search
+SELECT * FROM units
+WHERE identifier ILIKE '%' || $1 || '%' OR similarity(identifier, $1) > 0.1
+ORDER BY similarity(identifier, $1) DESC;

--- a/verify_trigram.sql
+++ b/verify_trigram.sql
@@ -1,0 +1,11 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+DROP TABLE IF EXISTS units;
+CREATE TABLE units (id serial PRIMARY KEY, identifier text NOT NULL);
+CREATE INDEX ON units USING gin (identifier gin_trgm_ops);
+
+INSERT INTO units (identifier) VALUES ('10-B');
+
+-- Search for "Apt 10B"
+SELECT identifier FROM units
+WHERE identifier ILIKE '%' || 'Apt 10B' || '%' OR similarity(identifier, 'Apt 10B') > 0.1;


### PR DESCRIPTION
## Summary
- add migration enabling `pg_trgm` and trigram indexes on tenant names and unit identifiers
- document example queries using `ILIKE` and trigram similarity for fuzzy matching
- add script showing that searching "Apt 10B" finds unit "10-B"

## Testing
- `su postgres -c "psql -v ON_ERROR_STOP=1 -f verify_trigram.sql"`


------
https://chatgpt.com/codex/tasks/task_e_68b69ca650208328b3a8b0cf4971253a