### PR TITLE
Add aging report with export options

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,44 @@
+from flask import Flask, Response, render_template, request
+from reporting import compute_aging, export_csv, export_pdf, load_invoices
+
+app = Flask(__name__)
+
+
+@app.route("/aging-report")
+def aging_report():
+    property_filter = request.args.get("property")
+    organization_filter = request.args.get("organization")
+    invoices = load_invoices()
+    aging, totals = compute_aging(
+        invoices,
+        property=property_filter,
+        organization=organization_filter,
+    )
+
+    export = request.args.get("export")
+    if export == "csv":
+        csv_data = export_csv(aging)
+        return Response(
+            csv_data,
+            mimetype="text/csv",
+            headers={"Content-Disposition": "attachment; filename=aging_report.csv"},
+        )
+    if export == "pdf":
+        pdf_bytes = export_pdf(aging)
+        return Response(
+            pdf_bytes,
+            mimetype="application/pdf",
+            headers={"Content-Disposition": "attachment; filename=aging_report.pdf"},
+        )
+
+    return render_template(
+        "aging_report.html",
+        aging=aging,
+        totals=totals,
+        property=property_filter,
+        organization=organization_filter,
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/data/invoices.json
+++ b/data/invoices.json
@@ -1,0 +1,7 @@
+[
+ {"id":1,"organization":"OrgA","property":"Property1","amount":1000,"paid_amount":200,"due_date":"2024-04-15"},
+ {"id":2,"organization":"OrgA","property":"Property2","amount":1500,"paid_amount":0,"due_date":"2024-03-01"},
+ {"id":3,"organization":"OrgB","property":"Property1","amount":2000,"paid_amount":500,"due_date":"2024-01-15"},
+ {"id":4,"organization":"OrgB","property":"Property2","amount":500,"paid_amount":0,"due_date":"2023-11-01"},
+ {"id":5,"organization":"OrgC","property":"Property3","amount":750,"paid_amount":100,"due_date":"2024-05-01"}
+]

--- a/reporting.py
+++ b/reporting.py
@@ -1,0 +1,90 @@
+import csv
+import datetime as _dt
+import io
+import json
+from collections import defaultdict
+from typing import Dict, Iterable, List, Tuple
+
+BUCKETS: List[Tuple[int, int]] = [(0, 30), (31, 60), (61, 90), (91, 10**9)]
+BUCKET_LABELS = ["0-30", "31-60", "61-90", "91+"]
+
+
+def load_invoices(path: str = "data/invoices.json") -> List[Dict]:
+    """Load invoices from a JSON file."""
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def compute_aging(
+    invoices: Iterable[Dict],
+    *,
+    property: str | None = None,
+    organization: str | None = None,
+    today: _dt.date | None = None,
+) -> Tuple[Dict[str, Dict], Dict[str, float]]:
+    """Compute aging buckets for outstanding invoices.
+
+    Returns mapping of bucket label to items and totals plus overall totals.
+    """
+
+    if today is None:
+        today = _dt.date.today()
+
+    results = {
+        label: {"items": [], "total": 0.0} for label in BUCKET_LABELS
+    }
+    totals = {"total_outstanding": 0.0}
+
+    for inv in invoices:
+        if property and inv.get("property") != property:
+            continue
+        if organization and inv.get("organization") != organization:
+            continue
+
+        outstanding = inv.get("amount", 0) - inv.get("paid_amount", 0)
+        if outstanding <= 0:
+            continue
+
+        due = _dt.date.fromisoformat(inv["due_date"])
+        days_overdue = (today - due).days
+        if days_overdue < 0:
+            # not yet due; treat as 0-30
+            days_overdue = 0
+
+        for (start, end), label in zip(BUCKETS, BUCKET_LABELS):
+            if start <= days_overdue <= end:
+                bucket = results[label]
+                bucket["items"].append(
+                    {
+                        **inv,
+                        "outstanding": outstanding,
+                        "days_overdue": days_overdue,
+                    }
+                )
+                bucket["total"] += outstanding
+                break
+        totals["total_outstanding"] += outstanding
+
+    return results, totals
+
+
+def export_csv(aging: Dict[str, Dict]) -> str:
+    """Return CSV string representing the aging summary."""
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["Bucket", "Outstanding"])
+    for label in BUCKET_LABELS:
+        writer.writerow([label, f"{aging[label]['total']:.2f}"])
+    return output.getvalue()
+
+from fpdf import FPDF
+
+def export_pdf(aging: Dict[str, Dict]) -> bytes:
+    """Return PDF bytes for the aging summary."""
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    pdf.cell(0, 10, "Aging Report", ln=True)
+    for label in BUCKET_LABELS:
+        pdf.cell(0, 10, f"{label}: {aging[label]['total']:.2f}", ln=True)
+    return pdf.output(dest="S").encode("latin-1")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+fpdf
+pytest

--- a/templates/aging_report.html
+++ b/templates/aging_report.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Aging Report</title>
+</head>
+<body>
+    <h1>Aging Report</h1>
+    {% if property %}<p>Property: {{ property }}</p>{% endif %}
+    {% if organization %}<p>Organization: {{ organization }}</p>{% endif %}
+    <table border="1" cellpadding="4" cellspacing="0">
+        <tr>
+            <th>Bucket</th>
+            <th>Outstanding</th>
+        </tr>
+        {% for label, data in aging.items() %}
+        <tr>
+            <td>{{ label }}</td>
+            <td>{{ "%.2f"|format(data.total) }}</td>
+        </tr>
+        {% endfor %}
+        <tr>
+            <td><strong>Total</strong></td>
+            <td><strong>{{ "%.2f"|format(totals.total_outstanding) }}</strong></td>
+        </tr>
+    </table>
+    <p>
+        <a href="?property={{ property }}&organization={{ organization }}&export=csv">Export CSV</a>
+        |
+        <a href="?property={{ property }}&organization={{ organization }}&export=pdf">Export PDF</a>
+    </p>
+</body>
+</html>

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,21 @@
+import datetime as dt
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from reporting import compute_aging
+
+
+def test_compute_aging_buckets():
+    invoices = [
+        {"amount": 100, "paid_amount": 0, "due_date": "2024-01-25", "organization": "OrgA", "property": "Prop1"},
+        {"amount": 200, "paid_amount": 50, "due_date": "2023-12-01", "organization": "OrgA", "property": "Prop1"},
+        {"amount": 300, "paid_amount": 0, "due_date": "2023-09-01", "organization": "OrgB", "property": "Prop2"},
+    ]
+    today = dt.date(2024, 2, 20)
+    aging, totals = compute_aging(invoices, today=today)
+    assert totals["total_outstanding"] == 100 + 150 + 300
+    assert aging["0-30"]["total"] == 100
+    assert aging["61-90"]["total"] == 150
+    assert aging["91+"]["total"] == 300


### PR DESCRIPTION
## Summary
- compute aging buckets for outstanding invoices with property and organization filters
- add CSV and PDF export endpoints
- show bucket totals and overall totals in HTML report

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b69ca8a57c832890c268fbfad883b7