### PR TITLE
Add PDF statement generation and delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.db
+statements/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # simple-invoice-website
-basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+Basic rent invoicing system that records payments and generates printable/PDF rent receipts.
+
+## Features
+
+- Aggregate charges, receipts, fees and payouts per property per month
+- Render monthly statements as PDF with organization branding
+- Download or email statements to property owners
+- Maintain history of generated statements
+
+## Usage
+
+1. Install requirements:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Initialize the database:
+
+```bash
+python database.py
+```
+
+3. Run the web server:
+
+```bash
+python app.py
+```
+
+Statements are available at `/statements/<property_id>/<year>/<month>/download`.
+Send a statement via email by POSTing JSON `{"email": "owner@example.com"}` to `/statements/<property_id>/<year>/<month>/email`.
+
+The server requires SMTP configuration via `SMTP_HOST` (and optional `SMTP_PORT`, `SMTP_FROM`) environment variables to send emails.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,68 @@
+from flask import Flask, send_file, request, jsonify
+from pathlib import Path
+import os
+import smtplib
+from email.message import EmailMessage
+
+from database import init_db, get_conn
+from statement_generator import generate_statement
+
+app = Flask(__name__)
+
+init_db()
+
+
+@app.route('/statements/<property_id>/<int:year>/<int:month>/download')
+def download_statement(property_id: str, year: int, month: int):
+    pdf_path = ensure_statement(property_id, year, month)
+    return send_file(pdf_path, as_attachment=True)
+
+
+def ensure_statement(property_id: str, year: int, month: int) -> Path:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        'SELECT pdf_path FROM statements WHERE property_id=? AND year=? AND month=?',
+        (property_id, year, month)
+    )
+    row = cur.fetchone()
+    conn.close()
+    if row:
+        return Path(row['pdf_path'])
+    return generate_statement(property_id, year, month)
+
+
+@app.route('/statements/<property_id>/<int:year>/<int:month>/email', methods=['POST'])
+def email_statement(property_id: str, year: int, month: int):
+    data = request.get_json(force=True)
+    email = data.get('email')
+    if not email:
+        return jsonify({'error': 'email required'}), 400
+    pdf_path = ensure_statement(property_id, year, month)
+    try:
+        send_email(email, pdf_path)
+    except Exception as exc:
+        return jsonify({'error': str(exc)}), 500
+    return jsonify({'status': 'sent'})
+
+
+def send_email(to_email: str, pdf_path: Path):
+    msg = EmailMessage()
+    msg['Subject'] = f"Your statement {pdf_path.stem}"
+    msg['From'] = os.getenv('SMTP_FROM', 'noreply@example.com')
+    msg['To'] = to_email
+    msg.set_content('Please find attached your monthly statement.')
+    with open(pdf_path, 'rb') as f:
+        data = f.read()
+    msg.add_attachment(data, maintype='application', subtype='pdf', filename=pdf_path.name)
+
+    smtp_host = os.getenv('SMTP_HOST')
+    smtp_port = int(os.getenv('SMTP_PORT', 25))
+    if not smtp_host:
+        raise RuntimeError('SMTP_HOST not configured')
+    with smtplib.SMTP(smtp_host, smtp_port) as smtp:
+        smtp.send_message(msg)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/database.py
+++ b/database.py
@@ -1,0 +1,50 @@
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+DB_PATH = Path('data.db')
+
+
+def get_conn():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    conn = get_conn()
+    cur = conn.cursor()
+    # Transactions table
+    cur.execute(
+        '''CREATE TABLE IF NOT EXISTS transactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            property_id TEXT NOT NULL,
+            date TEXT NOT NULL,
+            type TEXT NOT NULL CHECK(type IN ('charge','receipt','fee','payout')),
+            amount REAL NOT NULL
+        )'''
+    )
+    # Owners table
+    cur.execute(
+        '''CREATE TABLE IF NOT EXISTS owners (
+            property_id TEXT PRIMARY KEY,
+            email TEXT NOT NULL
+        )'''
+    )
+    # Statements history table
+    cur.execute(
+        '''CREATE TABLE IF NOT EXISTS statements (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            property_id TEXT NOT NULL,
+            year INTEGER NOT NULL,
+            month INTEGER NOT NULL,
+            pdf_path TEXT NOT NULL,
+            generated_at TEXT NOT NULL
+        )'''
+    )
+    conn.commit()
+    conn.close()
+
+
+if __name__ == '__main__':
+    init_db()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+fpdf2
+

--- a/statement_generator.py
+++ b/statement_generator.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+from datetime import datetime
+from typing import Dict
+
+from fpdf import FPDF
+
+from database import get_conn
+
+ORGANIZATION_NAME = "Simple Rentals LLC"
+STATEMENTS_DIR = Path('statements')
+STATEMENTS_DIR.mkdir(exist_ok=True)
+
+
+def aggregate(property_id: str, year: int, month: int) -> Dict[str, float]:
+    """Aggregate transactions by type for a property and month."""
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        '''SELECT type, SUM(amount) as total FROM transactions
+           WHERE property_id=? AND strftime('%Y', date)=? AND strftime('%m', date)=?
+           GROUP BY type''',
+        (property_id, str(year), f"{month:02d}")
+    )
+    rows = cur.fetchall()
+    conn.close()
+    aggregates = {row['type']: row['total'] for row in rows}
+    for key in ['charge', 'receipt', 'fee', 'payout']:
+        aggregates.setdefault(key, 0.0)
+    return aggregates
+
+
+def generate_pdf(property_id: str, year: int, month: int, aggregates: Dict[str, float]) -> Path:
+    """Create PDF statement with organization branding."""
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", 'B', 16)
+    pdf.cell(200, 10, ORGANIZATION_NAME, ln=True, align='C')
+    pdf.set_font("Arial", size=12)
+    pdf.cell(200, 10, f"Statement for Property {property_id} - {month:02d}/{year}", ln=True, align='L')
+    pdf.ln(5)
+    for key, label in (
+        ('charge', 'Charges'),
+        ('receipt', 'Receipts'),
+        ('fee', 'Fees'),
+        ('payout', 'Payouts'),
+    ):
+        pdf.cell(200, 10, f"{label}: ${aggregates[key]:.2f}", ln=True, align='L')
+    output_path = STATEMENTS_DIR / f"statement_{property_id}_{year}_{month:02d}.pdf"
+    pdf.output(str(output_path))
+    return output_path
+
+
+def record_statement(property_id: str, year: int, month: int, pdf_path: Path) -> None:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        '''INSERT INTO statements(property_id, year, month, pdf_path, generated_at)
+           VALUES (?,?,?,?,?)''',
+        (property_id, year, month, str(pdf_path), datetime.utcnow().isoformat())
+    )
+    conn.commit()
+    conn.close()
+
+
+def generate_statement(property_id: str, year: int, month: int) -> Path:
+    aggregates = aggregate(property_id, year, month)
+    pdf_path = generate_pdf(property_id, year, month, aggregates)
+    record_statement(property_id, year, month, pdf_path)
+    return pdf_path


### PR DESCRIPTION
## Summary
- track transactions and statement history in SQLite
- generate monthly PDF statements with organization branding
- allow download and email of statements via Flask endpoints

## Testing
- `python -m py_compile app.py statement_generator.py database.py`
- `python - <<'PYTHON'
from database import init_db, get_conn
from datetime import date
from statement_generator import generate_statement
init_db()
conn = get_conn()
cur = conn.cursor()
cur.execute("INSERT INTO owners(property_id, email) VALUES (?, ?)", ('P1', 'owner@example.com'))
transactions = [
    ('P1', '2024-01-05', 'charge', 1000.0),
    ('P1', '2024-01-06', 'fee', 50.0),
    ('P1', '2024-01-10', 'receipt', 1000.0),
    ('P1', '2024-01-15', 'payout', 950.0),
]
cur.executemany("INSERT INTO transactions(property_id, date, type, amount) VALUES (?,?,?,?)", transactions)
conn.commit()
conn.close()
print('setup complete')
path = generate_statement('P1', 2024, 1)
print('generated', path)
PYTHON`


------
https://chatgpt.com/codex/tasks/task_e_68b69ca96d70832891a7aa9c5d5f0f1b