### PR TITLE
Add lease document archiving with temporary download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # simple-invoice-website
-basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+Basic rent invoicing system that records payments and generates printable/PDF rent receipts.
+
+## Lease document archives
+
+This example includes a small Flask application that can collect all documents
+for a lease, stream them into a ZIP archive with a `manifest.json` file and
+optionally persist the archive for audit purposes. A temporary download link is
+produced via signed tokens and a minimal UI button is available at
+`/leases/<lease_id>/documents` to trigger the download.
+
+### Running locally
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Visit `http://localhost:5000/leases/lease1/documents` and click **Download ZIP**
+to generate a temporary link and retrieve the archive.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,60 @@
+from flask import Flask, jsonify, render_template, request, send_file, url_for
+from itsdangerous import URLSafeSerializer, BadSignature, SignatureExpired
+import time
+from archive import get_document_keys, stream_zip_with_manifest
+
+app = Flask(__name__)
+# Secret key for signing temporary links; in real deployments use env vars.
+app.secret_key = "change-me"
+serializer = URLSafeSerializer(app.secret_key)
+
+
+@app.route("/leases/<lease_id>/documents")
+def lease_documents(lease_id: str):
+    """Render a simple page listing documents with download button."""
+    keys = get_document_keys(lease_id)
+    return render_template("lease_documents.html", lease_id=lease_id, keys=keys)
+
+
+@app.route("/leases/<lease_id>/documents/link")
+def generate_link(lease_id: str):
+    """Return a temporary download link for the lease's document archive."""
+    token = serializer.dumps({"lease_id": lease_id, "ts": int(time.time())})
+    url = url_for("download_token", token=token, _external=True)
+    return jsonify({"url": url})
+
+
+@app.route("/download/<token>")
+def download_token(token: str):
+    """Download archive after validating temporary token."""
+    try:
+        data = serializer.loads(token, max_age=300)  # five-minute expiry
+    except (BadSignature, SignatureExpired):
+        return "Link expired or invalid", 400
+
+    lease_id = data["lease_id"]
+    store = request.args.get("store") == "1"
+    buffer = stream_zip_with_manifest(lease_id, store=store)
+    return send_file(
+        buffer,
+        mimetype="application/zip",
+        as_attachment=True,
+        download_name=f"lease_{lease_id}.zip",
+    )
+
+
+@app.route("/leases/<lease_id>/documents/archive")
+def direct_archive(lease_id: str):
+    """Directly stream ZIP archive without generating a link."""
+    store = request.args.get("store") == "1"
+    buffer = stream_zip_with_manifest(lease_id, store=store)
+    return send_file(
+        buffer,
+        mimetype="application/zip",
+        as_attachment=True,
+        download_name=f"lease_{lease_id}.zip",
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/archive.py
+++ b/archive.py
@@ -1,0 +1,54 @@
+import io
+import json
+import os
+import time
+import zipfile
+from typing import Dict, List
+
+# In-memory document store for example purposes.
+# In a real application, replace with calls to external storage (e.g., S3).
+DOCUMENT_STORE: Dict[str, Dict[str, bytes]] = {
+    'lease1': {
+        'contract.txt': b'Sample contract text for lease1',
+        'invoice.pdf': b'%PDF-1.4 example invoice for lease1',
+    },
+    'lease2': {
+        'agreement.txt': b'Lease agreement text for lease2',
+    },
+}
+
+
+def get_document_keys(lease_id: str) -> List[str]:
+    """Return the list of document keys for a lease."""
+    return list(DOCUMENT_STORE.get(lease_id, {}).keys())
+
+
+def stream_zip_with_manifest(lease_id: str, store: bool = False) -> io.BytesIO:
+    """Create a ZIP archive of all lease documents including a manifest.
+
+    Args:
+        lease_id: Lease identifier whose documents should be archived.
+        store: When True, persist a copy of the archive for audit purposes.
+
+    Returns:
+        BytesIO containing the ZIP archive positioned at start.
+    """
+    docs = DOCUMENT_STORE.get(lease_id, {})
+    buffer = io.BytesIO()
+    manifest = []
+    with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for key, content in docs.items():
+            zf.writestr(key, content)
+            manifest.append({'key': key, 'size': len(content)})
+        zf.writestr('manifest.json', json.dumps(manifest))
+
+    buffer.seek(0)
+
+    if store:
+        os.makedirs('archives', exist_ok=True)
+        filename = f'archives/lease_{lease_id}_{int(time.time())}.zip'
+        with open(filename, 'wb') as f:
+            f.write(buffer.getbuffer())
+        buffer.seek(0)
+
+    return buffer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+itsdangerous

--- a/templates/lease_documents.html
+++ b/templates/lease_documents.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Lease Documents</title>
+  </head>
+  <body>
+    <h1>Documents for lease {{ lease_id }}</h1>
+    <ul>
+      {% for key in keys %}
+      <li>{{ key }}</li>
+      {% endfor %}
+    </ul>
+    <button id="download">Download ZIP</button>
+    <script>
+      document.getElementById('download').addEventListener('click', async () => {
+        const resp = await fetch('{{ url_for("generate_link", lease_id=lease_id) }}');
+        const data = await resp.json();
+        window.location = data.url;
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Archive all lease documents into a ZIP with manifest and optional audit storage
- Provide Flask endpoints to generate temporary download links for archives
- Add simple UI page with button to trigger document archive download

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py archive.py`


------
https://chatgpt.com/codex/tasks/task_e_68b69ce5f6c083289bb2ae3c4df00149