### PR TITLE
Add experiment analytics logging and cleanup tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # simple-invoice-website
 basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+## Experiment data retention
+
+Analytics events are stored in a local SQLite database (`analytics.db`).
+Each event can be associated with an `experiment_id` and a `variant_id` to
+support A/B testing or other experiments.
+
+Old experiment data should be cleaned up regularly:
+
+- **Retention period** – experiment records are kept for 90 days by default.
+- **Purging** – run `analytics.cleanup.purge_expired_events` to permanently
+  remove rows older than the retention period.
+- **Anonymisation** – run `analytics.cleanup.anonymize_old_experiments` to
+  strip event payloads for outdated records while retaining aggregate counts.
+
+Schedule these cleanup tasks (e.g. via cron) to maintain a small database
+and respect privacy requirements.

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,0 +1,6 @@
+"""Analytics package for experiment event logging and cleanup."""
+
+from .event_logger import log_event
+from .cleanup import DEFAULT_TTL_DAYS, purge_expired_events, anonymize_old_experiments
+
+__all__ = ["log_event", "purge_expired_events", "anonymize_old_experiments", "DEFAULT_TTL_DAYS"]

--- a/analytics/cleanup.py
+++ b/analytics/cleanup.py
@@ -1,0 +1,58 @@
+"""Helpers for removing or anonymising old experiment analytics data."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+DB_PATH = Path("analytics.db")
+
+
+DEFAULT_TTL_DAYS = 90
+
+
+def purge_expired_events(*, ttl_days: int = DEFAULT_TTL_DAYS, db_path: Path = DB_PATH) -> int:
+    """Delete analytics rows older than the supplied TTL.
+
+    Returns the number of deleted rows."""
+    cutoff = datetime.utcnow() - timedelta(days=ttl_days)
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(
+            "DELETE FROM analytics_events WHERE created_at < ?", (cutoff,)
+        )
+        return cur.rowcount
+
+
+def anonymize_old_experiments(*, ttl_days: int = DEFAULT_TTL_DAYS, db_path: Path = DB_PATH) -> int:
+    """Remove potentially identifying event data for outdated experiments.
+
+    Returns the number of anonymised rows."""
+    cutoff = datetime.utcnow() - timedelta(days=ttl_days)
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(
+            "UPDATE analytics_events SET event_data = NULL WHERE created_at < ?",
+            (cutoff,),
+        )
+        return cur.rowcount
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Cleanup analytics experiment data")
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    purge_cmd = sub.add_parser("purge", help="Delete events older than TTL")
+    purge_cmd.add_argument("ttl", type=int, help="Retention window in days")
+
+    anon_cmd = sub.add_parser("anonymize", help="Anonymize events older than TTL")
+    anon_cmd.add_argument("ttl", type=int, help="Retention window in days")
+
+    args = parser.parse_args()
+    if args.action == "purge":
+        removed = purge_expired_events(ttl_days=args.ttl)
+        print(f"Purged {removed} rows")
+    else:
+        updated = anonymize_old_experiments(ttl_days=args.ttl)
+        print(f"Anonymized {updated} rows")

--- a/analytics/event_logger.py
+++ b/analytics/event_logger.py
@@ -1,0 +1,71 @@
+"""Logging utilities for analytics events.
+
+Events are stored in a local SQLite database with experiment and variant
+identifiers so that experiments can be analyzed later."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+DB_PATH = Path("analytics.db")
+
+
+def _ensure_schema(db_path: Path = DB_PATH) -> None:
+    """Create the analytics table if it does not already exist."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS analytics_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_name TEXT NOT NULL,
+                event_data TEXT,
+                experiment_id TEXT,
+                variant_id TEXT,
+                created_at TIMESTAMP NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_analytics_created_at ON analytics_events(created_at)"
+        )
+
+
+def log_event(
+    event_name: str,
+    event_data: Optional[Mapping[str, Any]] = None,
+    *,
+    experiment_id: Optional[str] = None,
+    variant_id: Optional[str] = None,
+    db_path: Path = DB_PATH,
+) -> None:
+    """Persist an analytics event with experiment metadata.
+
+    Parameters
+    ----------
+    event_name:
+        The name of the event that occurred.
+    event_data:
+        Arbitrary structured data about the event. Must be JSON serialisable.
+    experiment_id:
+        Identifier for the experiment that generated the event.
+    variant_id:
+        Identifier for the specific variant within the experiment.
+    db_path:
+        Path to the SQLite database used for storage.
+    """
+
+    _ensure_schema(db_path)
+
+    payload = json.dumps(event_data or {})
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO analytics_events (event_name, event_data, experiment_id, variant_id, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (event_name, payload, experiment_id, variant_id, datetime.utcnow()),
+        )


### PR DESCRIPTION
## Summary
- log analytics events with experiment and variant identifiers
- manage retention via TTL-based purging or anonymization (default 90 days)
- document experiment data retention and cleanup schedule

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b69ce9a69c8328b9e0a687997ac519