### PR TITLE
Add feature flags for autopay, ACH, and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # simple-invoice-website
+
 basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+## Feature Flags
+
+The application uses environment-driven feature flags to safely roll out risky capabilities.
+
+- `ENABLE_AUTOPAY` – allows automatic payment of invoices. Off by default.
+- `ENABLE_ACH_PAYMENTS` – enables ACH payment processing. Off by default.
+- `ENABLE_NEW_SEARCH` – switches to the new invoice search implementation. Off by default.
+
+Set a flag to `true` in the environment to enable the related feature.

--- a/featureFlags.js
+++ b/featureFlags.js
@@ -1,0 +1,7 @@
+const flags = {
+  ENABLE_AUTOPAY: process.env.ENABLE_AUTOPAY === 'true',
+  ENABLE_ACH_PAYMENTS: process.env.ENABLE_ACH_PAYMENTS === 'true',
+  ENABLE_NEW_SEARCH: process.env.ENABLE_NEW_SEARCH === 'true',
+};
+
+module.exports = flags;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "simple-invoice-website",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test.js"
+  }
+}

--- a/payment.js
+++ b/payment.js
@@ -1,0 +1,17 @@
+const flags = require('./featureFlags');
+
+function autopay(invoiceId) {
+  if (!flags.ENABLE_AUTOPAY) {
+    throw new Error('Autopay feature disabled');
+  }
+  return `Autopay processed for invoice ${invoiceId}`;
+}
+
+function processACHPayment(details) {
+  if (!flags.ENABLE_ACH_PAYMENTS) {
+    throw new Error('ACH payments feature disabled');
+  }
+  return `ACH payment processed for account ${details.account}`;
+}
+
+module.exports = { autopay, processACHPayment };

--- a/search.js
+++ b/search.js
@@ -1,0 +1,11 @@
+const flags = require('./featureFlags');
+
+function searchInvoices(term, invoices) {
+  if (!flags.ENABLE_NEW_SEARCH) {
+    // Fallback: return unfiltered list
+    return invoices;
+  }
+  return invoices.filter(inv => inv.toLowerCase().includes(term.toLowerCase()));
+}
+
+module.exports = { searchInvoices };

--- a/test.js
+++ b/test.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const flags = require('./featureFlags');
+const payment = require('./payment');
+const { searchInvoices } = require('./search');
+
+function withFlags(newFlags, fn) {
+  const original = { ...flags };
+  Object.assign(flags, newFlags);
+  try {
+    fn();
+  } finally {
+    Object.assign(flags, original);
+  }
+}
+
+function testAutopay() {
+  withFlags({ ENABLE_AUTOPAY: false }, () => {
+    assert.throws(() => payment.autopay('INV1'));
+  });
+  withFlags({ ENABLE_AUTOPAY: true }, () => {
+    assert.strictEqual(
+      payment.autopay('INV1'),
+      'Autopay processed for invoice INV1'
+    );
+  });
+}
+
+function testACHPayment() {
+  withFlags({ ENABLE_ACH_PAYMENTS: false }, () => {
+    assert.throws(() => payment.processACHPayment({ account: '123' }));
+  });
+  withFlags({ ENABLE_ACH_PAYMENTS: true }, () => {
+    assert.strictEqual(
+      payment.processACHPayment({ account: '123' }),
+      'ACH payment processed for account 123'
+    );
+  });
+}
+
+function testSearch() {
+  const invoices = ['January', 'February'];
+  withFlags({ ENABLE_NEW_SEARCH: false }, () => {
+    assert.deepStrictEqual(searchInvoices('Jan', invoices), invoices);
+  });
+  withFlags({ ENABLE_NEW_SEARCH: true }, () => {
+    assert.deepStrictEqual(searchInvoices('Jan', invoices), ['January']);
+  });
+}
+
+testAutopay();
+testACHPayment();
+testSearch();
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- add environment-based feature flags for autopay, ACH payments, and the new search
- guard autopay and ACH payment handlers as well as search logic with the new flags
- document feature flags and provide basic tests covering on/off behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b69ce705908328a8cda5e8f7c490bf