### PR TITLE
Add Vercel preview deployment and QA documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Summary
+- 
+
+## QA Checklist
+- [ ] Payments are running in **test mode**
+- [ ] Emails route to the **sandbox**
+- [ ] Vercel preview link added to PR description

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,48 @@
+name: Vercel Preview Deployment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel
+        id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Update PR Description with Preview URL
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const url = process.env.PREVIEW_URL;
+            const {data: pr} = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number,
+            });
+            const previewLine = `Preview deployment: ${url}`;
+            const body = pr.body ? pr.body.replace(/Preview deployment:.*\n?/,'').trim() + '\n\n' + previewLine : previewLine;
+            await github.rest.pulls.update({
+              ...context.repo,
+              pull_number: context.issue.number,
+              body,
+            });
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}

--- a/docs/qa-checklist.md
+++ b/docs/qa-checklist.md
@@ -1,0 +1,7 @@
+# QA Checklist
+
+Before merging any pull request, ensure the following checks have been completed:
+
+- [ ] Payments are configured to run in **test mode**
+- [ ] Emails are directed to the **sandbox** environment
+- [ ] Preview deployment link is present in the PR description

--- a/docs/reviewer-verification.md
+++ b/docs/reviewer-verification.md
@@ -1,0 +1,8 @@
+# Reviewer Verification Steps
+
+To validate a pull request:
+
+1. Open the preview URL listed in the PR description.
+2. Perform a test payment using sandbox credentials to confirm the system runs in **test mode**.
+3. Trigger an email notification and verify it is routed to the **sandbox** inbox.
+4. Confirm the application functions as expected in the preview environment.


### PR DESCRIPTION
## Summary
- add GitHub Action for Vercel preview deployments that annotates PRs with the preview URL
- introduce QA checklist and reviewer verification docs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b69ce83da883288b37cc9cfb44e9c8