### PR TITLE
Add feature flag runbook and kill switch implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # simple-invoice-website
-basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+Basic rent invoicing system that records payments and generates printable/PDF rent receipts.
+
+## Feature Flags
+
+Feature flags for this project are managed via `feature_flags.py` and the `feature_flags.json` configuration file. See `runbooks/feature-flag-rollout.md` for instructions on gradually enabling features, using the kill switch, monitoring during ramps, and rolling back.

--- a/feature_flags.json
+++ b/feature_flags.json
@@ -1,0 +1,6 @@
+{
+  "newInvoiceUI": {
+    "rollout": 1,
+    "kill_switch": false
+  }
+}

--- a/feature_flags.py
+++ b/feature_flags.py
@@ -1,0 +1,55 @@
+import json
+import random
+from pathlib import Path
+
+
+class FeatureFlagManager:
+    """Simple feature flag manager with percentage rollouts and kill switch."""
+
+    def __init__(self, config_path: str = "feature_flags.json"):
+        self.config_path = Path(config_path)
+        self._load()
+
+    def _load(self) -> None:
+        if self.config_path.exists():
+            with self.config_path.open() as f:
+                self.flags = json.load(f)
+        else:
+            self.flags = {}
+
+    def is_enabled(self, feature_name: str, user_id: str | None = None) -> bool:
+        flag = self.flags.get(feature_name)
+        if not flag:
+            return False
+        if flag.get("kill_switch"):
+            return False
+        rollout = flag.get("rollout", 0)
+        if user_id is None:
+            return random.random() * 100 < rollout
+        bucket = hash(user_id) % 100
+        return bucket < rollout
+
+    def set_rollout(self, feature_name: str, percent: int) -> None:
+        flag = self.flags.setdefault(feature_name, {})
+        flag["rollout"] = percent
+        self._save()
+
+    def activate_kill_switch(self, feature_name: str) -> None:
+        flag = self.flags.setdefault(feature_name, {})
+        flag["kill_switch"] = True
+        self._save()
+
+    def deactivate_kill_switch(self, feature_name: str) -> None:
+        flag = self.flags.setdefault(feature_name, {})
+        flag["kill_switch"] = False
+        self._save()
+
+    def _save(self) -> None:
+        with self.config_path.open("w") as f:
+            json.dump(self.flags, f, indent=2)
+
+
+if __name__ == "__main__":
+    manager = FeatureFlagManager()
+    feature = "newInvoiceUI"
+    print(f"{feature} enabled for demo user:", manager.is_enabled(feature, user_id="demo"))

--- a/runbooks/feature-flag-rollout.md
+++ b/runbooks/feature-flag-rollout.md
@@ -1,0 +1,36 @@
+# Feature Flag Rollout Runbook
+
+This guide describes how to enable new features gradually from 1% to 100% using feature flags, how to disable features immediately with a kill switch, and how to monitor and roll back changes.
+
+## Prerequisites
+- Define the feature in `feature_flags.json`.
+- Ensure monitoring dashboards and alerts are configured for key metrics.
+- Communicate the rollout plan to the team.
+
+## Gradual Rollout Procedure
+1. **Initial Deployment (1%)**
+   - Set the feature's `rollout` value to `1`.
+   - Deploy the configuration and verify that a small cohort receives the feature.
+   - Monitor metrics for errors, latency, and user behaviour.
+2. **Incremental Increases**
+   - Increase the rollout to `5%`, `10%`, `25%`, `50%`, and `100%` as confidence grows.
+   - After each increase, allow time to observe metrics and user feedback.
+3. **Kill Switch**
+   - To immediately disable a feature, set `kill_switch` to `true` for that feature and redeploy the configuration.
+   - This bypasses the rollout percentage and disables the feature for all users.
+
+## Monitoring and Alerts
+- Track key metrics (error rate, response time, traffic) throughout the ramp.
+- Configure alerting thresholds so anomalies trigger notifications to the on-call channel.
+- During rollout, review dashboards after each change and acknowledge alerts promptly.
+
+## Rollback Procedures
+1. Set the feature's `rollout` value back to `0` or enable the kill switch.
+2. Redeploy the configuration and verify the feature is disabled.
+3. Conduct a postmortem if the rollback was due to an incident.
+
+## Team Training
+- Review this runbook with the team before each feature rollout.
+- Practice using the kill switch and reverting rollouts in a staging environment.
+- Ensure on-call engineers know how to update `feature_flags.json` and redeploy quickly.
+


### PR DESCRIPTION
## Summary
- add runbook for feature flag rollouts, kill switch, monitoring, and rollback training
- implement simple feature flag manager with kill switch support
- document feature flag usage in README

## Testing
- `python -m py_compile feature_flags.py`
- `python feature_flags.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b69ce8d9748328b3ea0e68380a39fe