### PR TITLE
Implement lease countersign and final PDF packet workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # simple-invoice-website
-basic rent invoicing system that records payments and generates printable/PDF rent receipts
+
+Basic rent invoicing system that records payments and generates printable/PDF rent receipts.
+
+## Lease packet workflow
+
+The `lease_packet` module demonstrates how to handle a landlord countersignature flow and generate a final signed packet for download:
+
+1. **Countersignature** – `request_landlord_countersign` can prompt the landlord in-app or route the request through a third-party provider.
+2. **Merge documents** – `merge_signed_documents` combines the lease summary and signed attachments into a single PDF.
+3. **Store final packet** – `store_final_packet` saves the merged PDF into a document library directory.
+4. **Download link** – `download_link` returns the path to the stored packet so it can be offered as a download in the lease interface.
+
+Run the tests to see the workflow in action:
+
+```bash
+pytest -q
+```

--- a/lease_packet.py
+++ b/lease_packet.py
@@ -1,0 +1,55 @@
+"""Lease document management module.
+
+This module provides a simple workflow for requesting landlord countersignatures,
+merging signed lease documents, storing the final packet, and exposing a download
+path. The implementation is simplified for demonstration purposes and does not
+integrate with a real signature provider.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Iterable, Optional
+
+from PyPDF2 import PdfMerger
+
+
+def request_landlord_countersign(lease_id: str, provider: Optional[str] = None) -> str:
+    """Simulate requesting a landlord countersignature.
+
+    Args:
+        lease_id: Identifier for the lease.
+        provider: Optional name of a third-party signature provider.
+
+    Returns:
+        A message describing how the countersignature was requested.
+    """
+    if provider:
+        return f"Requested landlord signature for lease {lease_id} via {provider}."
+    return f"Prompted landlord to sign lease {lease_id} within the app."
+
+
+def merge_signed_documents(lease_summary: Path, signed_docs: Iterable[Path], output_path: Path) -> Path:
+    """Merge lease summary with signed documents into a single PDF."""
+    merger = PdfMerger()
+    merger.append(str(lease_summary))
+    for doc in signed_docs:
+        merger.append(str(doc))
+    with output_path.open("wb") as f:
+        merger.write(f)
+    merger.close()
+    return output_path
+
+
+def store_final_packet(merged_pdf: Path, document_library: Path) -> Path:
+    """Store the merged PDF in the document library directory."""
+    document_library.mkdir(parents=True, exist_ok=True)
+    dest = document_library / merged_pdf.name
+    shutil.copy(merged_pdf, dest)
+    return dest
+
+
+def download_link(lease_id: str, document_library: Path) -> Optional[Path]:
+    """Return the path to the stored packet for download."""
+    expected = document_library / f"{lease_id}_final_packet.pdf"
+    return expected if expected.exists() else None

--- a/test_lease_packet.py
+++ b/test_lease_packet.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from PyPDF2 import PdfWriter
+
+from lease_packet import (
+    download_link,
+    merge_signed_documents,
+    request_landlord_countersign,
+    store_final_packet,
+)
+
+
+def _blank_pdf(path: Path) -> Path:
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    with path.open("wb") as f:
+        writer.write(f)
+    return path
+
+
+def test_countersign_message():
+    msg = request_landlord_countersign("123")
+    assert "landlord" in msg
+    msg_provider = request_landlord_countersign("123", provider="DocuSign")
+    assert "DocuSign" in msg_provider
+
+
+def test_merge_and_store(tmp_path: Path):
+    summary = _blank_pdf(tmp_path / "summary.pdf")
+    docs = [_blank_pdf(tmp_path / "sign1.pdf"), _blank_pdf(tmp_path / "sign2.pdf")]
+    output = tmp_path / "123_final_packet.pdf"
+    merged = merge_signed_documents(summary, docs, output)
+    assert merged.exists()
+    library = tmp_path / "library"
+    stored = store_final_packet(merged, library)
+    assert stored.exists() and stored.parent == library
+    link = download_link("123", library)
+    assert link and link.exists()


### PR DESCRIPTION
## Summary
- add `lease_packet` module to handle landlord countersign requests
- merge lease summary and signed documents into single PDF
- store and expose final signed packet for download

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69c799df88328963b480c620c5eea