### PR TITLE
feat: add custom 404 and 500 pages

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+import Link from 'next/link';
+
+export default function ErrorPage({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4 text-center">
+      <h1 className="text-2xl font-bold">500 - Something went wrong</h1>
+      <p>{error.message}</p>
+      <button onClick={() => reset()} className="underline">
+        Try again
+      </button>
+      <nav className="flex gap-4">
+        <Link href="/tenant" className="underline">
+          Tenant Dashboard
+        </Link>
+        <Link href="/admin" className="underline">
+          Admin Dashboard
+        </Link>
+      </nav>
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4 text-center">
+      <h1 className="text-2xl font-bold">404 - Page Not Found</h1>
+      <p>The page you are looking for could not be found.</p>
+      <nav className="flex gap-4">
+        <Link href="/tenant" className="underline">
+          Tenant Dashboard
+        </Link>
+        <Link href="/admin" className="underline">
+          Admin Dashboard
+        </Link>
+      </nav>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add global 404 page with links to tenant and admin dashboards
- add custom 500 error page including retry and dashboard links

## Testing
- `npm test`
- `npx next dev` *(fails: Cannot find module './render-server')*

------
https://chatgpt.com/codex/tasks/task_e_68b6f11da90c83288204e03e83c8ac43