### PR TITLE
feat: add conditional rate limiter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
+        "ioredis": "^5.4.1",
         "sqlite3": "^5.1.7"
       }
     },
@@ -19,6 +20,12 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.1.tgz",
+      "integrity": "sha512-bYtU8avhGIcje3IhvF9aSjsa5URMZBHnwKtOvXsT4sfYy9gppW11gLPT/9oNqlJZD47yPKveQFTAFWpHjKvUoQ==",
+      "license": "MIT"
     },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
@@ -337,6 +344,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -447,6 +463,15 @@
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -999,6 +1024,30 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz",
+      "integrity": "sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.3.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
@@ -1047,6 +1096,18 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1609,6 +1670,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -1941,6 +2023,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^5.1.0",
+    "ioredis": "^5.4.1",
     "sqlite3": "^5.1.7"
   }
 }

--- a/server.js
+++ b/server.js
@@ -2,10 +2,67 @@ const express = require('express');
 const path = require('path');
 const { initDb, addStatus, getStatuses } = require('./database');
 
+// Optional Redis client - only used when a Redis URL is provided
+let Redis;
+try {
+  Redis = require('ioredis');
+} catch (e) {
+  // ioredis not installed; Redis-backed limiter will be disabled
+}
+
 const app = express();
 initDb();
 
+// Rate limiter configuration
+const WINDOW_MS = parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10) || 60_000; // 1 minute
+const MAX_REQUESTS = parseInt(process.env.RATE_LIMIT_MAX, 10) ||
+  (process.env.NODE_ENV === 'development' ? 5 : 100);
+
+let redisClient;
+if (process.env.REDIS_URL && Redis) {
+  redisClient = new Redis(process.env.REDIS_URL);
+}
+
+const memoryStore = new Map();
+
+async function rateLimiter(req, res, next) {
+  const key = req.ip;
+  const now = Date.now();
+
+  try {
+    if (redisClient) {
+      const ttl = await redisClient.ttl(key);
+      const count = await redisClient.incr(key);
+      if (ttl === -1) {
+        await redisClient.pexpire(key, WINDOW_MS);
+      }
+      if (count > MAX_REQUESTS) {
+        res.set('Retry-After', (ttl > 0 ? ttl : Math.ceil(WINDOW_MS / 1000)).toString());
+        return res.status(429).send('Too Many Requests');
+      }
+    } else {
+      const entry = memoryStore.get(key) || { count: 0, start: now };
+      if (now - entry.start > WINDOW_MS) {
+        entry.count = 1;
+        entry.start = now;
+      } else {
+        entry.count += 1;
+      }
+      memoryStore.set(key, entry);
+      if (entry.count > MAX_REQUESTS) {
+        const retry = Math.ceil((WINDOW_MS - (now - entry.start)) / 1000);
+        res.set('Retry-After', retry.toString());
+        return res.status(429).send('Too Many Requests');
+      }
+    }
+    return next();
+  } catch (err) {
+    return next(err);
+  }
+}
+
 app.use(express.json());
+app.use(rateLimiter);
 app.use(express.static(path.join(__dirname, 'public')));
 
 // Webhook endpoint for provider to send status updates


### PR DESCRIPTION
## Summary
- add rate limiter that uses Redis when configured, otherwise memory store
- default to low threshold in development for easier testing

## Testing
- `npm test`
- `NODE_ENV=development node server.js &`
- `for i in 1 2 3 4 5 6; do curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/lease/1/status; done`

------
https://chatgpt.com/codex/tasks/task_e_68b6f11a821c83288f6fd7550b49861c