### PR TITLE
Seed admin credentials and document defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+
+node_modules/

--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ Set environment variables for AWS to use S3:
 export AWS_REGION=us-east-1
 export S3_BUCKET=your-bucket
 ```
+
+### Default Credentials (Development)
+
+The seed script creates default accounts for convenience:
+
+- Admin: `admin@example.com` with password `admin123`
+- Tenant: `tenant@example.com`
+
+These credentials are intended for local development only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "express": "^5.1.0",
         "sqlite3": "^5.1.7"
       }
@@ -173,6 +174,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
     "node_modules/bindings": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^5.1.0",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "bcryptjs": "^2.4.3"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model Unit {
 model TenantProfile {
   id     Int     @id @default(autoincrement())
   name   String
+  email  String?
   leases Lease[]
 }
 
@@ -34,4 +35,11 @@ model Lease {
   unitId      Int
   tenant      TenantProfile @relation(fields: [tenantId], references: [id])
   tenantId    Int
+}
+
+model User {
+  id       Int    @id @default(autoincrement())
+  email    String @unique
+  password String
+  role     String
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,9 +1,19 @@
 const { PrismaClient } = require('@prisma/client');
+const bcrypt = require('bcryptjs');
 const prisma = new PrismaClient();
 
 async function main() {
+  const adminEmail = 'admin@example.com';
+  const adminPassword = 'admin123';
+  const tenantEmail = 'tenant@example.com';
+
+  const hashedPassword = await bcrypt.hash(adminPassword, 10);
+  const admin = await prisma.user.create({
+    data: { email: adminEmail, password: hashedPassword, role: 'admin' }
+  });
+
   const unit = await prisma.unit.create({ data: { name: 'Unit A' } });
-  const tenant = await prisma.tenantProfile.create({ data: { name: 'Alice' } });
+  const tenant = await prisma.tenantProfile.create({ data: { name: 'Alice', email: tenantEmail } });
   const lease = await prisma.lease.create({
     data: {
       unitId: unit.id,
@@ -17,6 +27,7 @@ async function main() {
       status: 'active'
     }
   });
+  console.log('Seeded admin', admin);
   console.log('Seeded lease', lease);
 }
 


### PR DESCRIPTION
## Summary
- add bcrypt hashing and seed default admin and tenant emails
- track tenant email and user model in Prisma schema
- document seeded credentials for local development

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f11987048328ba5ec685fa455450