### PR TITLE
Add Playwright test for invoice print preview

### DIFF
--- a/invoice.html
+++ b/invoice.html
@@ -4,6 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Invoice</title>
+  <style>
+    @media print {
+      nav { display: none; }
+      body { margin: 0; }
+    }
+  </style>
 </head>
 <body>
   <nav>
@@ -17,6 +23,10 @@
     <section>
       <h2>Invoice Details</h2>
       <p>Invoice information will be displayed here.</p>
+    </section>
+    <section id="totals">
+      <h2>Totals</h2>
+      <p>Total Due: $0.00</p>
     </section>
   </main>
   <footer>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "express": "^5.1.0",
         "sqlite3": "^5.1.7"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.55.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -44,6 +47,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -699,6 +718,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -1469,6 +1503,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node -e \"console.log('no tests')\""
+    "test": "playwright test"
   },
   "keywords": [],
   "author": "",
@@ -13,5 +13,8 @@
   "dependencies": {
     "express": "^5.1.0",
     "sqlite3": "^5.1.7"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.0"
   }
 }

--- a/tests/invoice-print.spec.ts
+++ b/tests/invoice-print.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+// Utility to get absolute path to invoice.html
+const invoicePath = path.join(__dirname, '..', 'invoice.html');
+
+// Dimensions for A4 and US Letter in pixels at 96 DPI
+const sizes = [
+  { name: 'A4', width: 794, height: 1123 },
+  { name: 'Letter', width: 816, height: 1056 }
+];
+
+test('invoice print preview hides navigation and fits standard paper', async ({ page }) => {
+  await page.goto('file://' + invoicePath);
+  await page.emulateMedia({ media: 'print' });
+
+  // Generate print preview PDF (buffer) to ensure page is printable
+  await page.pdf({ format: 'A4' });
+
+  // Navigation should be hidden in print mode
+  await expect(page.locator('nav')).toBeHidden();
+
+  for (const size of sizes) {
+    await page.setViewportSize({ width: size.width, height: size.height });
+
+    // Ensure content does not overflow the page dimensions
+    const bodySize = await page.evaluate(() => ({
+      width: document.body.scrollWidth,
+      height: document.body.scrollHeight
+    }));
+
+    expect(bodySize.width, `${size.name} width overflow`).toBeLessThanOrEqual(size.width);
+    expect(bodySize.height, `${size.name} height overflow`).toBeLessThanOrEqual(size.height);
+
+    // Totals section should be fully visible (not clipped)
+    const totalsBox = await page.locator('#totals').boundingBox();
+    expect(totalsBox, `${size.name} totals not found`).not.toBeNull();
+    if (totalsBox) {
+      expect(totalsBox.y + totalsBox.height, `${size.name} totals clipped`).toBeLessThanOrEqual(size.height);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- hide navigation during printing and add totals section to invoice
- add Playwright test ensuring invoice print preview fits A4/Letter and totals not clipped
- wire up Playwright test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f111e0e48328bb28544570c47b09