### PR TITLE
Add Stripe Test Clock utility and E2E billing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+node_modules/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+stripe

--- a/stripe_test_clock.py
+++ b/stripe_test_clock.py
@@ -1,0 +1,40 @@
+import os
+import time
+import stripe
+
+stripe.api_key = os.environ.get("STRIPE_API_KEY", "")
+
+def create_test_clock(start_time: int | None = None) -> stripe.test_helpers.TestClock:
+    """Create a Stripe Test Clock.
+
+    Parameters
+    ----------
+    start_time: int | None
+        Unix timestamp to start the clock at. If not provided, current time is used.
+
+    Returns
+    -------
+    stripe.test_helpers.TestClock
+        The created test clock object.
+    """
+    if start_time is None:
+        start_time = int(time.time())
+    return stripe.test_helpers.TestClock.create(frozen_time=start_time)
+
+
+def advance_test_clock(clock_id: str, new_time: int) -> stripe.test_helpers.TestClock:
+    """Advance an existing test clock to a new frozen time.
+
+    Parameters
+    ----------
+    clock_id: str
+        Identifier of the test clock to advance.
+    new_time: int
+        Unix timestamp to advance the clock to.
+
+    Returns
+    -------
+    stripe.test_helpers.TestClock
+        The updated test clock object.
+    """
+    return stripe.test_helpers.TestClock.advance(clock_id, frozen_time=new_time)

--- a/tests/test_stripe_test_clock.py
+++ b/tests/test_stripe_test_clock.py
@@ -1,0 +1,80 @@
+import os
+import time
+
+import pytest
+import stripe
+
+from stripe_test_clock import create_test_clock, advance_test_clock
+
+stripe.api_key = os.environ.get("STRIPE_API_KEY", "")
+
+
+pytestmark = pytest.mark.skipif(
+    not stripe.api_key, reason="STRIPE_API_KEY not set"
+)
+
+
+def _create_failing_customer(clock_id: str):
+    customer = stripe.Customer.create(test_clock=clock_id)
+    payment_method = stripe.PaymentMethod.create(
+        type="card",
+        card={
+            "number": "4000000000000002",  # always fails
+            "exp_month": 12,
+            "exp_year": 2030,
+            "cvc": "123",
+        },
+    )
+    stripe.PaymentMethod.attach(payment_method.id, customer=customer.id)
+    stripe.Customer.modify(
+        customer.id,
+        invoice_settings={"default_payment_method": payment_method.id},
+    )
+    return customer
+
+
+def test_invoice_due_date_and_dunning():
+    start = int(time.time())
+    clock = create_test_clock(start)
+
+    # Create manual invoice to test due date handling
+    manual_customer = stripe.Customer.create(test_clock=clock.id)
+    stripe.InvoiceItem.create(customer=manual_customer.id, amount=1000, currency="usd")
+    invoice = stripe.Invoice.create(
+        customer=manual_customer.id,
+        collection_method="send_invoice",
+        days_until_due=1,
+    )
+    invoice = stripe.Invoice.finalize_invoice(invoice.id)
+    assert invoice.due_date is not None
+
+    # Advance past due date
+    advance_test_clock(clock.id, invoice.due_date + 24 * 3600)
+    invoice = stripe.Invoice.retrieve(invoice.id)
+    clock_state = stripe.test_helpers.TestClock.retrieve(clock.id)
+    assert invoice.due_date < clock_state.frozen_time
+
+    # Create subscription with failing payment to test dunning
+    customer = _create_failing_customer(clock.id)
+    subscription = stripe.Subscription.create(
+        customer=customer.id,
+        items=[
+            {
+                "price_data": {
+                    "currency": "usd",
+                    "unit_amount": 1000,
+                    "recurring": {"interval": "month"},
+                    "product_data": {"name": "Test"},
+                }
+            }
+        ],
+    )
+    invoice = stripe.Invoice.retrieve(subscription.latest_invoice)
+    stripe.Invoice.finalize_invoice(invoice.id)
+    invoice = stripe.Invoice.retrieve(invoice.id)
+    first_attempt = invoice.next_payment_attempt
+    attempt_count = invoice.attempt_count
+
+    advance_test_clock(clock.id, first_attempt)
+    invoice = stripe.Invoice.retrieve(invoice.id)
+    assert invoice.attempt_count == attempt_count + 1


### PR DESCRIPTION
## Summary
- add helper for creating and advancing Stripe Test Clocks
- cover invoice due date and dunning scenarios in E2E tests
- include Stripe dependency and ignore node_modules

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6f10fac2883288e6f57b52d89bb6b