### PR TITLE
Add Playwright invoice workflow test and CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,25 @@
+name: Playwright Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - name: Install Playwright Browsers (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: npx playwright install --with-deps
+      - name: Install Playwright Browsers
+        if: matrix.os != 'ubuntu-latest'
+        run: npx playwright install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __pycache__/
 *.pyc
+node_modules/
+playwright-report/
+test-results/
+*.db

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "express": "^5.1.0",
         "sqlite3": "^5.1.7"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.55.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -44,6 +47,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -699,6 +718,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -1469,6 +1503,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node -e \"console.log('no tests')\""
+    "test": "playwright test"
   },
   "keywords": [],
   "author": "",
@@ -13,5 +13,8 @@
   "dependencies": {
     "express": "^5.1.0",
     "sqlite3": "^5.1.7"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: /.*\.spec\.ts/,
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+  webServer: {
+    command: 'node server.js',
+    port: 3000,
+    timeout: 120000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/admin-invoice.spec.ts
+++ b/tests/admin-invoice.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * End-to-end flow: admin triggers invoice creation and marks it as sent,
+ * tenant can view updated timeline.
+ */
+test('admin invoice lifecycle visible to tenant', async ({ page }) => {
+  // Admin login - for this demo app, admin page is open
+  await page.goto('/admin.html');
+  await expect(page).toHaveTitle(/Admin/);
+
+  // Simulate invoice creation
+  await page.evaluate(() =>
+    fetch('/webhook', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ leaseId: '1', status: 'created' }),
+    })
+  );
+
+  // Mark invoice as sent
+  await page.evaluate(() =>
+    fetch('/webhook', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ leaseId: '1', status: 'sent' }),
+    })
+  );
+
+  // Tenant views timeline
+  await page.goto('/lease.html?id=1');
+  const timeline = page.locator('#timeline');
+  await expect(timeline).toContainText('created');
+  await expect(timeline).toContainText('sent');
+});


### PR DESCRIPTION
## Summary
- add Playwright setup and invoice lifecycle test
- run Playwright in GitHub Actions across Linux, Windows, and macOS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f10c120c8328b5624a2fe579a9f3