### PR TITLE
docs: add developer setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,36 @@ basic rent invoicing system that records payments and generates printable/PDF re
 
 This demo adds a minimal lease document system. Start the server and open `/leases/<leaseId>` to upload files and view previously uploaded documents. Files are stored in Amazon S3 when `AWS_REGION` and `S3_BUCKET` are configured; otherwise they are kept locally under `uploads/`. Download links use signed URLs that expire after one hour.
 
-### Running
+## Development Setup
 
-```
-npm install
-npm start
-```
+1. Clone the repository and install dependencies:
+   ```bash
+   git clone https://github.com/your-org/simple-invoice-website.git
+   cd simple-invoice-website
+   npm ci
+   ```
+2. Copy environment variables template:
+   ```bash
+   cp .env.example .env
+   ```
+3. Start services:
+   ```bash
+   docker compose up -d
+   ```
+4. Apply database migrations and seed data:
+   ```bash
+   npx prisma migrate deploy
+   node prisma/seed.js
+   ```
+5. Forward Stripe webhooks in a separate terminal:
+   ```bash
+   stripe listen --forward-to http://localhost:3000/webhook
+   ```
+6. Launch the development server:
+   ```bash
+   npm start
+   ```
+7. Have another developer follow these steps to validate the flow.
 
 Set environment variables for AWS to use S3:
 


### PR DESCRIPTION
## Summary
- document local development setup: clone repo, install dependencies, copy env file
- add steps to start Docker services, run migrations & seed data, forward Stripe webhooks, and start dev server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f1090f9c8328a70c0df16b506d15