### PR TITLE
Add environment-aware Sentry initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@sentry/node": "^7.120.4",
         "express": "^5.1.0",
         "sqlite3": "^5.1.7"
       }
@@ -44,6 +45,85 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.4.tgz",
+      "integrity": "sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.4.tgz",
+      "integrity": "sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.4.tgz",
+      "integrity": "sha512-kkBTLk053XlhDCg7OkBQTIMF4puqFibeRO3E3YiVc4PGLnocXMaVpOSCkMqAc1k1kZ09UgGi8DxfQhnFEjUkpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.120.4.tgz",
+      "integrity": "sha512-qq3wZAXXj2SRWhqErnGCSJKUhPSlZ+RGnCZjhfjHpP49KNpcd9YdPTIUsFMgeyjdh6Ew6aVCv23g1hTP0CHpYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/integrations": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.4.tgz",
+      "integrity": "sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.4.tgz",
+      "integrity": "sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -948,6 +1028,12 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -1047,6 +1133,24 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node -e \"console.log('no tests')\""
+    "test": "node tests/test_sentry.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@sentry/node": "^7.120.4",
     "express": "^5.1.0",
     "sqlite3": "^5.1.7"
   }

--- a/sentry.js
+++ b/sentry.js
@@ -1,0 +1,13 @@
+const Sentry = require('@sentry/node');
+
+function initSentry(options = {}) {
+  if (process.env.NODE_ENV === 'production') {
+    Sentry.init({ dsn: process.env.SENTRY_DSN, ...options });
+    return true;
+  } else {
+    console.log('Sentry disabled in development environment');
+    return false;
+  }
+}
+
+module.exports = { Sentry, initSentry };

--- a/server.js
+++ b/server.js
@@ -1,9 +1,12 @@
 const express = require('express');
 const path = require('path');
 const { initDb, addStatus, getStatuses } = require('./database');
+const { initSentry } = require('./sentry');
 
 const app = express();
 initDb();
+
+initSentry();
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));

--- a/tests/test_sentry.js
+++ b/tests/test_sentry.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const { Sentry, initSentry } = require('../sentry');
+
+async function resetSentry() {
+  const client = Sentry.getCurrentHub().getClient();
+  if (client) {
+    await client.close();
+    Sentry.getCurrentHub().setClient(null);
+  }
+}
+
+async function testDevelopment() {
+  await resetSentry();
+  process.env.NODE_ENV = 'development';
+  const events = [];
+  const transport = () => ({
+    send: (envelope) => {
+      events.push(envelope);
+      return Promise.resolve({ status: 'success' });
+    },
+    flush: () => Promise.resolve(true),
+  });
+  const enabled = initSentry({ transport });
+  Sentry.captureMessage('dev test');
+  await Sentry.flush(200);
+  assert.strictEqual(enabled, false);
+  assert.strictEqual(events.length, 0);
+}
+
+async function testProduction() {
+  await resetSentry();
+  process.env.NODE_ENV = 'production';
+  process.env.SENTRY_DSN = 'https://examplePublicKey@o0.ingest.sentry.io/0';
+  const events = [];
+  const transport = () => ({
+    send: (envelope) => {
+      events.push(envelope);
+      return Promise.resolve({ status: 'success' });
+    },
+    flush: () => Promise.resolve(true),
+  });
+  const enabled = initSentry({ transport });
+  Sentry.captureMessage('prod test');
+  await Sentry.flush(200);
+  assert.strictEqual(enabled, true);
+  assert.strictEqual(events.length, 1);
+}
+
+(async () => {
+  await testDevelopment();
+  await testProduction();
+  console.log('Sentry tests passed');
+})();


### PR DESCRIPTION
## Summary
- initialize Sentry only in production and log when disabled
- add Sentry helper and tests to ensure events only send in prod
- run Sentry tests via npm script

## Testing
- `npm test`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6f112f4b083289d32d37e80da88ae