### PR TITLE
docs: document vercel env pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,19 @@ Set environment variables for AWS to use S3:
 export AWS_REGION=us-east-1
 export S3_BUCKET=your-bucket
 ```
+
+### Vercel Environment Variables
+
+Set any required environment variables in the Vercel dashboard or via the CLI:
+
+```
+vercel env add <KEY> staging
+```
+
+Sync the staging values to a local `.env.local` file with:
+
+```
+npm run env:pull
+```
+
+The command runs `vercel env pull` and writes the staging values to `.env.local`. Inspect the file to verify the values were pulled correctly.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node -e \"console.log('no tests')\""
+    "test": "node -e \"console.log('no tests')\"",
+    "env:pull": "npx --yes vercel env pull .env.local --environment=staging"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `env:pull` npm script for fetching staging variables
- document using `vercel env add` and `npm run env:pull` in README

## Testing
- `npm test`
- `npm run env:pull` *(fails: No existing credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f107fab8832893702c4a982dc99b