### PR TITLE
Configure CSP headers for Stripe in dev

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,32 @@
+const cspHeader = `
+  default-src 'self';
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' https://js.stripe.com https://m.stripe.network;
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' data: https://q.stripe.com;
+  frame-src https://js.stripe.com https://hooks.stripe.com;
+  connect-src 'self' https://api.stripe.com https://m.stripe.network;
+`;
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: cspHeader.replace(/\n/g, ''),
+  },
+];
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  async headers() {
+    if (process.env.NODE_ENV === 'development') {
+      return [
+        {
+          source: '/:path*',
+          headers: securityHeaders,
+        },
+      ];
+    }
+    return [];
+  },
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- add development-only Content-Security-Policy headers
- allow Stripe domains and required sources for Payment Element

## Testing
- `npm test`
- `curl -I http://localhost:3000/pay`

------
https://chatgpt.com/codex/tasks/task_e_68b6f10381cc8328829257183792802e