### PR TITLE
Add build step and tenant dashboard route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 *.pyc
+node_modules/
+dist/
+*.db

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "basic rent invoicing system that records payments and generates printable/PDF rent receipts",
   "main": "server.js",
   "scripts": {
+    "build": "node -e \"console.log('build successful')\"",
     "start": "node server.js",
     "test": "node -e \"console.log('no tests')\""
   },

--- a/public/tenant/index.html
+++ b/public/tenant/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Tenant Dashboard</title>
+</head>
+<body>
+  <h1>Tenant Dashboard</h1>
+  <p>Welcome to the tenant dashboard.</p>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -6,6 +6,11 @@ const app = express();
 initDb();
 
 app.use(express.json());
+// Tenant dashboard
+app.get('/tenant', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'tenant', 'index.html'));
+});
+
 app.use(express.static(path.join(__dirname, 'public')));
 
 // Webhook endpoint for provider to send status updates


### PR DESCRIPTION
## Summary
- add placeholder build script to package.json
- serve new tenant dashboard page at `/tenant`
- ignore transient build and database files

## Testing
- `npm run build`
- `npm run start & curl -s -o /tmp/tenant.html -w '%{http_code}' http://localhost:3000/tenant`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f105d3448328b210f1864332448e