### PR TITLE
Allow localhost uploads by enabling CORS

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,27 @@ const app = express();
 initDb();
 
 app.use(express.json());
+
+// Allow browser clients running on localhost to access the API and uploaded files.
+app.use((req, res, next) => {
+  const origin = req.headers.origin || '';
+  if (origin.startsWith('http://localhost') || origin.startsWith('http://127.0.0.1')) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  }
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(204);
+  }
+  next();
+});
+
 app.use(express.static(path.join(__dirname, 'public')));
+app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+
+// Lease document endpoints
+const leaseDocuments = require('./routes/leaseDocuments');
+app.use('/api/leases/:leaseId/documents', leaseDocuments);
 
 // Webhook endpoint for provider to send status updates
 app.post('/webhook', (req, res) => {

--- a/services/storage.js
+++ b/services/storage.js
@@ -1,5 +1,10 @@
-const { S3Client, PutObjectCommand, GetObjectCommand } = require('@aws-sdk/client-s3');
-const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
+let S3Client, PutObjectCommand, GetObjectCommand, getSignedUrl;
+try {
+  ({ S3Client, PutObjectCommand, GetObjectCommand } = require('@aws-sdk/client-s3'));
+  ({ getSignedUrl } = require('@aws-sdk/s3-request-presigner'));
+} catch (e) {
+  // AWS SDK not installed; local storage will be used.
+}
 const path = require('path');
 const fs = require('fs');
 
@@ -11,7 +16,9 @@ function getS3Client() {
 async function uploadBuffer(buffer, key, mimetype) {
   const client = getS3Client();
   if (!client) {
-    const filePath = path.join(__dirname, '../uploads', key);
+    const uploadDir = path.join(__dirname, '../uploads');
+    fs.mkdirSync(uploadDir, { recursive: true });
+    const filePath = path.join(uploadDir, key);
     fs.writeFileSync(filePath, buffer);
     return { storageKey: key, local: true };
   }


### PR DESCRIPTION
## Summary
- enable CORS for localhost clients and serve uploaded files
- mount lease document routes for browser uploads
- make storage service use local files when AWS SDK is missing

## Testing
- `npm test`
- `curl -i -H "Origin: http://localhost:5173" -F "type=test" -F "signedBy=me" -F "signedOn=2024-01-01" -F "document=@sample.txt" http://localhost:3000/api/leases/123/documents`
- `curl -i -H "Origin: http://localhost:5173" http://localhost:3000/uploads/aef03ebe-7b16-421d-b403-a34dcef60cbc.txt`
- `curl -i -X OPTIONS -H "Origin: http://localhost:5173" -H "Access-Control-Request-Method: POST" http://localhost:3000/api/leases/123/documents`


------
https://chatgpt.com/codex/tasks/task_e_68b6f104bbdc8328a6a5e080faa6f327