### PR TITLE
Add Docker healthcheck for /api/health

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:18-slim
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install --production
+
+COPY . .
+
+# Install curl for healthcheck
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 CMD curl -f http://localhost:3000/api/health || exit 1
+
+CMD ["npm", "start"]

--- a/server.js
+++ b/server.js
@@ -8,6 +8,11 @@ initDb();
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));
 
+// Simple health check endpoint
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
 // Webhook endpoint for provider to send status updates
 app.post('/webhook', (req, res) => {
   const { leaseId, status } = req.body;


### PR DESCRIPTION
## Summary
- add `/api/health` route for basic service health
- include Dockerfile with healthcheck hitting `/api/health`

## Testing
- `npm test`
- `docker build -t invoice-app .` *(fails: Cannot connect to the Docker daemon)*
- `docker ps` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f102def08328a2340ae4cd09bb4b