### PR TITLE
Add credentials-based auth with seeded admin

### DIFF
--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { signIn } from "next-auth/react";
 
 const formSchema = z.object({
   email: z.string().email({ message: "Valid email required" }),
@@ -24,9 +25,12 @@ export default function LoginPage() {
     defaultValues: { email: "", password: "" },
   });
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
-    // TODO: handle login
-    console.log(values);
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    await signIn("credentials", {
+      email: values.email,
+      password: values.password,
+      redirect: false,
+    });
   }
 
   return (

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth";
+import { buildAuthOptions } from "@/authOptions";
+
+const handler = NextAuth(buildAuthOptions());
+
+export { handler as GET, handler as POST };

--- a/authOptions.ts
+++ b/authOptions.ts
@@ -1,5 +1,8 @@
 import type { AuthOptions, SessionStrategy } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
+import CredentialsProvider from "next-auth/providers/credentials";
+import { compare } from "bcryptjs";
+import prisma from "./lib/prisma";
 
 const isProd = process.env.NODE_ENV === "production";
 
@@ -12,6 +15,25 @@ export const buildAuthOptions = (adapter?: Adapter): AuthOptions => {
     session: {
       strategy: sessionStrategy,
     },
+    providers: [
+      CredentialsProvider({
+        name: "Credentials",
+        credentials: {
+          email: { label: "Email", type: "text" },
+          password: { label: "Password", type: "password" },
+        },
+        async authorize(credentials) {
+          if (!credentials?.email || !credentials.password) return null;
+          const user = await prisma.user.findUnique({
+            where: { email: credentials.email },
+          });
+          if (!user) return null;
+          const isValid = await compare(credentials.password, user.password);
+          if (!isValid) return null;
+          return { id: user.id.toString(), email: user.email };
+        },
+      }),
+    ],
     cookies: {
       sessionToken: {
         options: {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,16 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@prisma/client": "^5.2.0",
+    "bcryptjs": "^2.4.3",
     "express": "^5.1.0",
+    "next": "^14.2.3",
+    "next-auth": "^4.24.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "sqlite3": "^5.1.7"
+  },
+  "devDependencies": {
+    "prisma": "^5.2.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,3 +35,9 @@ model Lease {
   tenant      TenantProfile @relation(fields: [tenantId], references: [id])
   tenantId    Int
 }
+
+model User {
+  id       Int    @id @default(autoincrement())
+  email    String @unique
+  password String
+}

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,7 +1,18 @@
 const { PrismaClient } = require('@prisma/client');
+const bcrypt = require('bcryptjs');
 const prisma = new PrismaClient();
 
 async function main() {
+  const adminPassword = await bcrypt.hash('admin', 10);
+  await prisma.user.upsert({
+    where: { email: 'admin@example.com' },
+    update: {},
+    create: {
+      email: 'admin@example.com',
+      password: adminPassword,
+    },
+  });
+
   const unit = await prisma.unit.create({ data: { name: 'Unit A' } });
   const tenant = await prisma.tenantProfile.create({ data: { name: 'Alice' } });
   const lease = await prisma.lease.create({


### PR DESCRIPTION
## Summary
- integrate credential provider into NextAuth using Prisma and bcrypt
- seed database with admin user and hashed password
- wire login page to submit credentials

## Testing
- `npm test`
- `node prisma/seed.js` *(fails: Cannot find module '@prisma/client')*


------
https://chatgpt.com/codex/tasks/task_e_68b6f0fdcda88328a8dc056a1e3388d3