### PR TITLE
feat: add sample data seeding script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+node_modules/

--- a/data/invoices.json
+++ b/data/invoices.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": 1,
+    "leaseId": 1,
+    "amount": 1200,
+    "dueDate": "2024-01-05",
+    "status": "unpaid"
+  },
+  {
+    "id": 2,
+    "leaseId": 1,
+    "amount": 1200,
+    "dueDate": "2024-02-05",
+    "status": "unpaid"
+  },
+  {
+    "id": 3,
+    "leaseId": 2,
+    "amount": 1100,
+    "dueDate": "2024-06-05",
+    "status": "unpaid"
+  }
+]

--- a/data/leases.json
+++ b/data/leases.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 1,
+    "tenantId": 1,
+    "unit": "A1",
+    "startDate": "2024-01-01",
+    "endDate": "2024-12-31",
+    "monthlyRent": 1200
+  },
+  {
+    "id": 2,
+    "tenantId": 2,
+    "unit": "B2",
+    "startDate": "2024-06-01",
+    "endDate": "2025-05-31",
+    "monthlyRent": 1100
+  }
+]

--- a/data/tenants.json
+++ b/data/tenants.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 1,
+    "name": "Alice Tenant",
+    "phoneNumber": "555-0001"
+  },
+  {
+    "id": 2,
+    "name": "Bob Tenant",
+    "phoneNumber": "555-0002"
+  }
+]

--- a/scripts/seed-sample.ts
+++ b/scripts/seed-sample.ts
@@ -1,0 +1,81 @@
+// @ts-nocheck
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import path from 'path';
+
+/**
+ * Seeds sample tenants, leases, and invoices into the data/ directory.
+ *
+ * The script overwrites existing files making it safe to run multiple times.
+ * To reset data, delete the generated JSON files in the data/ directory.
+ */
+
+interface Tenant {
+  id: number;
+  name: string;
+  phoneNumber?: string;
+}
+
+interface Lease {
+  id: number;
+  tenantId: number;
+  unit: string;
+  startDate: string; // ISO string
+  endDate: string;   // ISO string
+  monthlyRent: number;
+}
+
+interface Invoice {
+  id: number;
+  leaseId: number;
+  amount: number;
+  dueDate: string; // ISO string
+  status: 'unpaid' | 'paid';
+}
+
+async function seed() {
+  const dataDir = path.join(__dirname, '..', 'data');
+  if (!existsSync(dataDir)) {
+    mkdirSync(dataDir, { recursive: true });
+  }
+
+  const tenants: Tenant[] = [
+    { id: 1, name: 'Alice Tenant', phoneNumber: '555-0001' },
+    { id: 2, name: 'Bob Tenant', phoneNumber: '555-0002' }
+  ];
+
+  const leases: Lease[] = [
+    {
+      id: 1,
+      tenantId: 1,
+      unit: 'A1',
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+      monthlyRent: 1200
+    },
+    {
+      id: 2,
+      tenantId: 2,
+      unit: 'B2',
+      startDate: '2024-06-01',
+      endDate: '2025-05-31',
+      monthlyRent: 1100
+    }
+  ];
+
+  const invoices: Invoice[] = [
+    { id: 1, leaseId: 1, amount: 1200, dueDate: '2024-01-05', status: 'unpaid' },
+    { id: 2, leaseId: 1, amount: 1200, dueDate: '2024-02-05', status: 'unpaid' },
+    { id: 3, leaseId: 2, amount: 1100, dueDate: '2024-06-05', status: 'unpaid' }
+  ];
+
+  writeFileSync(path.join(dataDir, 'tenants.json'), JSON.stringify(tenants, null, 2));
+  writeFileSync(path.join(dataDir, 'leases.json'), JSON.stringify(leases, null, 2));
+  writeFileSync(path.join(dataDir, 'invoices.json'), JSON.stringify(invoices, null, 2));
+
+  console.log('Seeded sample data to data/');
+}
+
+seed().catch((err) => {
+  console.error('Failed to seed sample data:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add TypeScript script to seed sample tenants, leases, and invoices
- ignore node_modules and include initial sample JSON data

## Testing
- `npx ts-node scripts/seed-sample.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f0fbd6e88328b105f2df4b61748d