### PR TITLE
Add devcontainer configuration for Node development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/devcontainers/base:bookworm

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "Simple Invoice Website",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts",
+      "pnpm": "latest"
+    }
+  },
+  "forwardPorts": [3000],
+  "postCreateCommand": "npm install"
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
+    "dev": "npm start",
     "test": "node -e \"console.log('no tests')\""
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add `.devcontainer` setup with Node and pnpm
- include dev script for starting server inside container

## Testing
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b6f0f47a6483289fef6e50a5e5bb15