### PR TITLE
Add multi-stage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+Dockerfile*
+.dockerignore
+.git
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Stage 1: install dependencies
+FROM node:20 AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+# Stage 2: build (run tests, compile if needed)
+FROM deps AS build
+COPY . .
+RUN npm test
+
+# Stage 3: runtime
+FROM node:20-alpine AS runtime
+WORKDIR /app
+COPY --from=build /app ./
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile with dependency, build, and runtime stages
- Expose port 3000 and start the server via `npm start`

## Testing
- `npm test`
- `docker build -t simple-invoice .` *(fails: Cannot connect to the Docker daemon)*
- `docker run --rm -p 3000:3000 simple-invoice` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f0f36e64832880293d0604f24f24