### PR TITLE
docs: add local HTTPS instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 __pycache__/
 *.pyc
+
+# Local TLS certificates
+certs/
+node_modules/
+data.db
+

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,4 @@
+localhost:8443 {
+    tls certs/localhost.pem certs/localhost-key.pem
+    reverse_proxy localhost:3000
+}

--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ Set environment variables for AWS to use S3:
 export AWS_REGION=us-east-1
 export S3_BUCKET=your-bucket
 ```
+
+### Local HTTPS
+
+See [docs/local-https.md](docs/local-https.md) for instructions on generating locally trusted certificates with mkcert and proxying the development server through Caddy.

--- a/docs/local-https.md
+++ b/docs/local-https.md
@@ -1,0 +1,40 @@
+# Local HTTPS with mkcert
+
+This project can be served locally over HTTPS using a locally-trusted certificate.
+
+## Generate certificates
+
+1. Install [mkcert](https://github.com/FiloSottile/mkcert).
+   - Debian/Ubuntu: `apt-get install mkcert`
+   - macOS (Homebrew): `brew install mkcert`
+2. Install the local certificate authority:
+   ```bash
+   mkcert -install
+   ```
+3. Create a directory for certificates and generate one for `localhost`:
+   ```bash
+   mkdir certs
+   mkcert -cert-file certs/localhost.pem -key-file certs/localhost-key.pem localhost 127.0.0.1 ::1
+   ```
+
+The `certs/` directory is ignored by git.
+
+## Caddy reverse proxy
+
+A sample `Caddyfile` is included at the repo root:
+
+```
+localhost:8443 {
+    tls certs/localhost.pem certs/localhost-key.pem
+    reverse_proxy localhost:3000
+}
+```
+
+Start the application and Caddy:
+
+```bash
+node server.js &
+caddy run --config Caddyfile
+```
+
+Visit https://localhost:8443 in your browser. The page should load without TLS warnings and proxy traffic to the development server running on port 3000.


### PR DESCRIPTION
## Summary
- document generating local certificates with mkcert
- add Caddy reverse proxy config for HTTPS dev
- ignore generated certificates and node_modules

## Testing
- `npm test`
- `curl -v https://localhost:8443/`

------
https://chatgpt.com/codex/tasks/task_e_68b6f0f183048328aa2695300f9f443a