### PR TITLE
feat: stub sms client in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 *.pyc
+.dev/
+node_modules/
+dist/

--- a/lib/sms.ts
+++ b/lib/sms.ts
@@ -1,11 +1,33 @@
-import Twilio from 'twilio';
 import type { Request, Response } from 'express';
+import fs from 'fs';
+import path from 'path';
 
-const accountSid = process.env.TWILIO_ACCOUNT_SID!;
-const authToken = process.env.TWILIO_AUTH_TOKEN!;
-const fromNumber = process.env.TWILIO_FROM_NUMBER!;
+const fromNumber = process.env.TWILIO_FROM_NUMBER || '';
+const isProd = process.env.NODE_ENV === 'production';
 
-const client = Twilio(accountSid, authToken);
+let client: any;
+
+if (isProd) {
+  // Defer Twilio import so dev environments don't need the package
+  const Twilio = require('twilio');
+  const accountSid = process.env.TWILIO_ACCOUNT_SID!;
+  const authToken = process.env.TWILIO_AUTH_TOKEN!;
+  client = Twilio(accountSid, authToken);
+} else {
+  const logDir = path.resolve('.dev');
+  const logFile = path.join(logDir, 'sms.log');
+  client = {
+    messages: {
+      /** Stub create simply appends the SMS to .dev/sms.log */
+      async create({ to, from, body }: { to: string; from: string; body: string }) {
+        await fs.promises.mkdir(logDir, { recursive: true });
+        const line = `${new Date().toISOString()}|${to}|${from}|${body}\n`;
+        await fs.promises.appendFile(logFile, line, 'utf8');
+        return { sid: 'stubbed' };
+      },
+    },
+  };
+}
 
 /** Send a rent due reminder SMS */
 export async function sendDueMessage(to: string, link: string) {
@@ -42,3 +64,4 @@ export async function handleWebhook(req: Request, res: Response) {
   res.type('text/xml');
   res.send('<Response></Response>');
 }
+

--- a/tests/dev_sms.test.ts
+++ b/tests/dev_sms.test.ts
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import path from 'path';
+
+import { sendDueMessage } from '../lib/sms';
+
+async function run() {
+  const logPath = path.join(__dirname, '..', '.dev', 'sms.log');
+  await fs.promises.rm(logPath, { force: true });
+  await sendDueMessage('+15555555555', 'http://example.com');
+  const contents = await fs.promises.readFile(logPath, 'utf8');
+  if (!contents.includes('http://example.com')) {
+    console.error('Log entry missing');
+    process.exit(1);
+  }
+  console.log('log contents:\n' + contents.trim());
+}
+
+run();
+


### PR DESCRIPTION
## Summary
- switch SMS library to use real Twilio in production and a stub logger in development
- write dev SMS messages to `.dev/sms.log` and add test to confirm
- ignore local build, dependency, and log directories

## Testing
- `npx ts-node -T --compiler-options '{"module":"commonjs"}' tests/dev_sms.test.ts`
- `npm test`
- `PYTHONPATH=. pytest`
- `npx tsc -p tsconfig.json` *(fails: Cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f0ee0b5c832890c775ef109d6c8e