### PR TITLE
Add MinIO dev service with bucket creation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,22 @@ Set environment variables for AWS to use S3:
 export AWS_REGION=us-east-1
 export S3_BUCKET=your-bucket
 ```
+
+### Local MinIO
+
+A `docker-compose.yml` file is provided to run a local [MinIO](https://min.io/) server for storing PDFs.
+
+Start the service:
+
+```
+docker compose up -d minio
+```
+
+Create the default `pdfs` bucket and upload a sample file using the provided script (requires the AWS CLI):
+
+```
+pip install awscli
+./scripts/create_pdf_bucket.sh
+```
+
+The script verifies the bucket exists and lists uploaded files. The MinIO web console is available at `http://localhost:9001`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    volumes:
+      - minio-data:/data
+volumes:
+  minio-data:

--- a/scripts/create_pdf_bucket.sh
+++ b/scripts/create_pdf_bucket.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENDPOINT=${ENDPOINT:-http://localhost:9000}
+BUCKET=${BUCKET:-pdfs}
+ACCESS_KEY=${MINIO_ROOT_USER:-minioadmin}
+SECRET_KEY=${MINIO_ROOT_PASSWORD:-minioadmin}
+
+export AWS_ACCESS_KEY_ID="$ACCESS_KEY"
+export AWS_SECRET_ACCESS_KEY="$SECRET_KEY"
+export AWS_DEFAULT_REGION=us-east-1
+
+# Create bucket if it does not exist
+aws --endpoint-url "$ENDPOINT" s3api create-bucket --bucket "$BUCKET" 2>/dev/null || true
+
+# Upload a sample file to verify
+aws --endpoint-url "$ENDPOINT" s3 cp README.md "s3://$BUCKET/readme.txt"
+
+# List bucket contents
+aws --endpoint-url "$ENDPOINT" s3 ls "s3://$BUCKET"


### PR DESCRIPTION
## Summary
- Add docker-compose MinIO service for local S3-compatible storage
- Include script to create `pdfs` bucket and upload sample file
- Document MinIO usage and setup instructions in README

## Testing
- `./scripts/create_pdf_bucket.sh`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6f0eef1288328abdefff18d592095