### PR TITLE
Seed tenants with Stripe customer IDs when missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "sqlite3": "^5.1.7"
+        "sqlite3": "^5.1.7",
+        "stripe": "^12.18.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -54,6 +55,15 @@
       "optional": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/abbrev": {
@@ -1997,6 +2007,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "12.18.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-12.18.0.tgz",
+      "integrity": "sha512-cYjgBM2SY/dTm8Lr6eMyyONaHTZHA/QjHxFUIW5WH8FevSRIGAVtXEmBkUXF1fsqe7QvvRgQSGSJZmjDacegGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -2091,6 +2114,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^5.1.0",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "stripe": "^12.18.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model Unit {
 model TenantProfile {
   id     Int     @id @default(autoincrement())
   name   String
+  stripeCustomerId String?
   leases Lease[]
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,54 @@
+import { PrismaClient } from '@prisma/client';
+import Stripe from 'stripe';
+
+const prisma = new PrismaClient();
+const stripe = new Stripe(process.env.STRIPE_API_KEY || '', {
+  apiVersion: '2022-11-15',
+});
+
+async function main() {
+  const unit = await prisma.unit.create({ data: { name: 'Unit A' } });
+  let tenant = await prisma.tenantProfile.create({ data: { name: 'Alice' } });
+
+  if (!tenant.stripeCustomerId) {
+    const customer = await stripe.customers.create({ name: tenant.name });
+    tenant = await prisma.tenantProfile.update({
+      where: { id: tenant.id },
+      data: { stripeCustomerId: customer.id },
+    });
+  }
+
+  const updatedTenant = await prisma.tenantProfile.findUnique({
+    where: { id: tenant.id },
+  });
+
+  if (!updatedTenant?.stripeCustomerId) {
+    throw new Error('Stripe customer ID was not saved.');
+  }
+
+  const lease = await prisma.lease.create({
+    data: {
+      unitId: unit.id,
+      tenantId: tenant.id,
+      startDate: new Date('2023-01-01'),
+      endDate: new Date('2023-12-31'),
+      monthlyRent: 1200,
+      deposit: 600,
+      currency: 'USD',
+      billingDay: 1,
+      status: 'active',
+    },
+  });
+
+  console.log('Seeded lease', lease);
+  console.log('Tenant stripe customer ID', updatedTenant.stripeCustomerId);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add optional `stripeCustomerId` to `TenantProfile` schema
- seed script now creates Stripe customer when missing and saves the ID
- add Stripe SDK dependency for seeding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f0e7e48c8328be57d6f052f850be