### PR TITLE
Add Stripe balance verification script

### DIFF
--- a/scripts/check-stripe.ts
+++ b/scripts/check-stripe.ts
@@ -1,0 +1,28 @@
+import Stripe from 'stripe';
+
+const requiredEnvVars = ['STRIPE_TEST_SECRET_KEY'];
+
+for (const envVar of requiredEnvVars) {
+  if (!process.env[envVar]) {
+    console.error(`Missing required environment variable: ${envVar}`);
+    process.exit(1);
+  }
+}
+
+const stripe = new Stripe(process.env.STRIPE_TEST_SECRET_KEY as string, {
+  apiVersion: '2023-10-16',
+});
+
+async function main() {
+  try {
+    const balance = await stripe.balance.retrieve();
+    console.log('Available balances:', balance.available);
+    console.log('Pending balances:', balance.pending);
+    process.exit(0);
+  } catch (error) {
+    console.error('Error retrieving Stripe balances:', error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add script to verify Stripe test key and log available/pending balances

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f0e675c8832889c57d51e34034eb