### PR TITLE
Add Stripe payment page for seeded invoices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+node_modules/

--- a/app/api/invoices/[invoiceId]/create-payment-intent/route.ts
+++ b/app/api/invoices/[invoiceId]/create-payment-intent/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { invoices } from '@/lib/data';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: '2022-11-15',
+});
+
+export async function GET(
+  request: Request,
+  { params }: { params: { invoiceId: string } }
+) {
+  const id = Number(params.invoiceId);
+  const invoice = invoices.find((inv) => inv.id === id);
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 });
+  }
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: invoice.amount,
+      currency: 'usd',
+      automatic_payment_methods: { enabled: true },
+      metadata: { invoiceId: String(invoice.id) },
+    });
+    return NextResponse.json({ clientSecret: paymentIntent.client_secret });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/app/api/invoices/[invoiceId]/route.ts
+++ b/app/api/invoices/[invoiceId]/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { invoices } from '@/lib/data';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { invoiceId: string } }
+) {
+  const id = Number(params.invoiceId);
+  const invoice = invoices.find((inv) => inv.id === id);
+  if (!invoice) {
+    return NextResponse.json({ error: 'Invoice not found' }, { status: 404 });
+  }
+  return NextResponse.json(invoice);
+}

--- a/app/tenant/pay/[invoiceId]/page.tsx
+++ b/app/tenant/pay/[invoiceId]/page.tsx
@@ -6,6 +6,12 @@ import { Elements, PaymentElement, useStripe, useElements } from "@stripe/react-
 
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || "");
 
+type Invoice = {
+  id: number;
+  amount: number;
+  description: string;
+};
+
 function CheckoutForm() {
   const stripe = useStripe();
   const elements = useElements();
@@ -45,14 +51,18 @@ function CheckoutForm() {
 
 export default function Page({ params }: { params: { invoiceId: string } }) {
   const [clientSecret, setClientSecret] = useState<string | null>(null);
+  const [invoice, setInvoice] = useState<Invoice | null>(null);
 
   useEffect(() => {
+    fetch(`/api/invoices/${params.invoiceId}`)
+      .then((res) => res.json())
+      .then((data) => setInvoice(data));
     fetch(`/api/invoices/${params.invoiceId}/create-payment-intent`)
       .then((res) => res.json())
       .then((data) => setClientSecret(data.clientSecret));
   }, [params.invoiceId]);
 
-  if (!clientSecret) {
+  if (!clientSecret || !invoice) {
     return <div>Loading...</div>;
   }
 
@@ -61,9 +71,15 @@ export default function Page({ params }: { params: { invoiceId: string } }) {
   };
 
   return (
-    <Elements stripe={stripePromise} options={options}>
-      <CheckoutForm />
-    </Elements>
+    <div>
+      <h1>Pay Invoice #{invoice.id}</h1>
+      <p>
+        {invoice.description} - ${(invoice.amount / 100).toFixed(2)}
+      </p>
+      <Elements stripe={stripePromise} options={options}>
+        <CheckoutForm />
+      </Elements>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- add API endpoint to fetch invoice info
- add API endpoint to create a PaymentIntent for an invoice
- enhance tenant payment page to display invoice details and collect payment via Stripe Payment Element
- ignore node_modules in git

## Testing
- `npm test`
- `PYTHONPATH=$PWD pytest`
- `STRIPE_SECRET_KEY=sk_test_... node - <<SCRIPT` *(fails: An error occurred with our connection to Stripe)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f0e90cf08328b3d66f54ec6a80b3