### PR TITLE
Add crypto secret generator and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+node_modules/

--- a/node-tests/generateSecret.test.js
+++ b/node-tests/generateSecret.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { generateSecret } = require('../scripts/generate-secret');
+
+test('generated secret has correct length', () => {
+  const secret = generateSecret();
+  assert.strictEqual(secret.length, 64); // 32 bytes -> 64 hex chars
+});
+
+test('generated secrets are random', () => {
+  const secret1 = generateSecret();
+  const secret2 = generateSecret();
+  assert.notStrictEqual(secret1, secret2);
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node -e \"console.log('no tests')\""
+    "test": "node --test node-tests",
+    "gen:secret": "node scripts/generate-secret.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/generate-secret.js
+++ b/scripts/generate-secret.js
@@ -1,0 +1,11 @@
+const crypto = require('crypto');
+
+function generateSecret(byteLength = 32) {
+  return crypto.randomBytes(byteLength).toString('hex');
+}
+
+if (require.main === module) {
+  console.log(generateSecret());
+}
+
+module.exports = { generateSecret };


### PR DESCRIPTION
## Summary
- add Node.js script to generate random secrets
- expose script via `npm run gen:secret`
- test that secrets have expected length and randomness

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f0e4d7dc83289ee1fcc90f215bee