### PR TITLE
Add development and build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,18 @@ This demo adds a minimal lease document system. Start the server and open `/leas
 
 ```
 npm install
+
+# start development server with automatic reload
+npm run dev
+
+# compile TypeScript utilities
+npm run build
+
+# run the server
 npm start
+
+# run tests
+npm test
 ```
 
 Set environment variables for AWS to use S3:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "express": "^5.1.0",
         "sqlite3": "^5.1.7"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@gar/promisify": {
@@ -2090,6 +2093,20 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unique-filename": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "basic rent invoicing system that records payments and generates printable/PDF rent receipts",
   "main": "server.js",
   "scripts": {
+    "dev": "node --watch server.js",
+    "build": "tsc lib/data.ts --outDir dist",
     "start": "node server.js",
     "test": "node -e \"console.log('no tests')\""
   },
@@ -13,5 +15,8 @@
   "dependencies": {
     "express": "^5.1.0",
     "sqlite3": "^5.1.7"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
## Summary
- add `dev` and `build` npm scripts for easier development
- document available npm scripts in README
- ignore node and build artifacts

## Testing
- `npm run build`
- `npm run dev`
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f0de02248328a04ffe4b99ac77ea