### PR TITLE
docs: add environment configuration example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# Environment configuration for simple-invoice-website
+
+# Node environment (development or production)
+NODE_ENV=development
+
+# Server port
+PORT=3000
+
+# Session storage strategy: "database" or "jwt"
+SESSION_STRATEGY=jwt
+
+# AWS S3 configuration
+AWS_REGION=
+S3_BUCKET=
+
+# Twilio SMS credentials
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_FROM_NUMBER=
+
+# Resend email API key
+RESEND_API_KEY=
+
+# OpenTelemetry configuration
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_SERVICE_NAME=simple-invoice-service
+
+# Stripe configuration
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
+STRIPE_API_KEY=
+
+# Public base URL for generating links
+NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 basic rent invoicing system that records payments and generates printable/PDF rent receipts
 
+## Setup
+
+Copy the example environment file and provide real values:
+
+```
+cp .env.example .env.local
+```
+
 ## Lease Documents
 
 This demo adds a minimal lease document system. Start the server and open `/leases/<leaseId>` to upload files and view previously uploaded documents. Files are stored in Amazon S3 when `AWS_REGION` and `S3_BUCKET` are configured; otherwise they are kept locally under `uploads/`. Download links use signed URLs that expire after one hour.
@@ -13,9 +21,4 @@ npm install
 npm start
 ```
 
-Set environment variables for AWS to use S3:
-
-```
-export AWS_REGION=us-east-1
-export S3_BUCKET=your-bucket
-```
+Set `AWS_REGION` and `S3_BUCKET` in `.env.local` to use S3. When these variables are not configured, files are stored locally.


### PR DESCRIPTION
## Summary
- provide `.env.example` listing env vars like Twilio, Stripe, and AWS S3
- document copying the example file to `.env.local` in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f0dbb430832889562633881c7128