### PR TITLE
chore: enforce node version on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node -e \"console.log('no tests')\""
+    "test": "node -e \"console.log('no tests')\"",
+    "preinstall": "node scripts/check-node-version.js"
   },
   "keywords": [],
   "author": "",
@@ -13,5 +14,8 @@
   "dependencies": {
     "express": "^5.1.0",
     "sqlite3": "^5.1.7"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+const { engines = {} } = require('../package.json');
+const required = process.env.REQUIRED_NODE_VERSION || engines.node || '';
+
+function parse(ver) {
+  const cleaned = String(ver).replace(/^[^\d]*/, '');
+  const [major = '0', minor = '0', patch = '0'] = cleaned.split('.');
+  return { major: Number(major), minor: Number(minor), patch: Number(patch) };
+}
+
+function isSatisfied(current, required) {
+  const c = parse(current);
+  const r = parse(required);
+  if (c.major !== r.major) return c.major > r.major;
+  if (c.minor !== r.minor) return c.minor > r.minor;
+  return c.patch >= r.patch;
+}
+
+if (required && !isSatisfied(process.versions.node, required)) {
+  console.error(`Unsupported Node.js version: ${process.versions.node}.`);
+  console.error(`Please use Node.js ${required} or higher.`);
+  console.error('Consider using nvm to manage versions: https://github.com/nvm-sh/nvm');
+  process.exit(1);
+}
+


### PR DESCRIPTION
## Summary
- add preinstall script to verify Node.js version
- require Node >=20 in package.json

## Testing
- `npm install`
- `REQUIRED_NODE_VERSION=999 npm install` (fails)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f0dce42c8328aa27a16649fc2633