### PR TITLE
Add Google authentication with domain-based access control

### DIFF
--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -12,6 +14,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { signIn } from "next-auth/react";
 
 const formSchema = z.object({
   email: z.string().email({ message: "Valid email required" }),
@@ -66,6 +69,14 @@ export default function LoginPage() {
 
           <Button type="submit" className="w-full">
             Log in
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={() => signIn("google")}
+          >
+            Sign in with Google
           </Button>
         </form>
       </Form>

--- a/authOptions.ts
+++ b/authOptions.ts
@@ -1,5 +1,7 @@
 import type { AuthOptions, SessionStrategy } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
+import GoogleProvider from "next-auth/providers/google";
+import { getUserRoleByEmail } from "./db/userRoles";
 
 const isProd = process.env.NODE_ENV === "production";
 
@@ -9,6 +11,18 @@ const sessionStrategy: SessionStrategy =
 
 export const buildAuthOptions = (adapter?: Adapter): AuthOptions => {
   const options: AuthOptions = {
+    providers: [
+      GoogleProvider({
+        clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+        authorization: {
+          params: {
+            // Restrict sign-ins to the configured Google Workspace domain
+            hd: process.env.GOOGLE_ALLOWED_DOMAIN,
+          },
+        },
+      }),
+    ],
     session: {
       strategy: sessionStrategy,
     },
@@ -19,6 +33,23 @@ export const buildAuthOptions = (adapter?: Adapter): AuthOptions => {
           httpOnly: true,
           sameSite: "lax",
         },
+      },
+    },
+    callbacks: {
+      // Reject sign-ins for emails outside the allowed domain
+      async signIn({ profile }) {
+        const domain = process.env.GOOGLE_ALLOWED_DOMAIN;
+        const email = profile?.email ?? "";
+        return domain ? email.endsWith(`@${domain}`) : true;
+      },
+      // Attach the user's role from the database to the session
+      async session({ session }) {
+        const email = session.user?.email;
+        if (email) {
+          const role = await getUserRoleByEmail(email);
+          (session.user as any).role = role;
+        }
+        return session;
       },
     },
   };

--- a/db/schema/user_roles.ts
+++ b/db/schema/user_roles.ts
@@ -1,0 +1,11 @@
+import { sqliteTable, integer, text } from "drizzle-orm/sqlite-core";
+
+// Stores the role for each authenticated user by email
+export const userRoles = sqliteTable("user_roles", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  email: text("email").notNull(),
+  role: text("role").notNull(),
+});
+
+export type UserRole = typeof userRoles.$inferSelect;
+export type NewUserRole = typeof userRoles.$inferInsert;

--- a/db/userRoles.ts
+++ b/db/userRoles.ts
@@ -1,0 +1,12 @@
+import { eq } from "drizzle-orm";
+import { db } from "./client";
+import { userRoles } from "./schema/user_roles";
+
+// Fetch the application role for a user by their email address
+export async function getUserRoleByEmail(email: string): Promise<string | null> {
+  const result = await db
+    .select({ role: userRoles.role })
+    .from(userRoles)
+    .where(eq(userRoles.email, email));
+  return result[0]?.role ?? null;
+}


### PR DESCRIPTION
## Summary
- integrate Google sign-in with domain restriction and session callbacks
- map Google emails to roles via database helper
- expose a Google sign-in option on the login page

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'invoice'; No module named 'stripe')*

------
https://chatgpt.com/codex/tasks/task_e_68b6bd867aa4832887424f481aa3138c