### PR TITLE
Add experiment metadata tagging and purge script

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface ExperimentMetadata {
+  experimentId: string;
+  variant: string;
+}
+
+interface AnalyticsEvent {
+  event: string;
+  experiment?: ExperimentMetadata;
+  timestamp: number;
+  expiresAt: number;
+}
+
+const DEFAULT_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const eventsFile = path.join(__dirname, '..', 'storage', 'experimentEvents.json');
+
+function readEvents(): AnalyticsEvent[] {
+  try {
+    const data = fs.readFileSync(eventsFile, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return [];
+  }
+}
+
+function writeEvents(events: AnalyticsEvent[]): void {
+  fs.mkdirSync(path.dirname(eventsFile), { recursive: true });
+  fs.writeFileSync(eventsFile, JSON.stringify(events, null, 2));
+}
+
+export function trackEvent(
+  event: string,
+  experiment?: ExperimentMetadata,
+  ttlMs: number = DEFAULT_TTL_MS,
+): void {
+  const events = readEvents();
+  const now = Date.now();
+  events.push({
+    event,
+    experiment,
+    timestamp: now,
+    expiresAt: now + ttlMs,
+  });
+  writeEvents(events);
+}
+
+export function purgeExpiredExperimentData(): void {
+  const now = Date.now();
+  const events = readEvents().filter((e) => e.expiresAt > now);
+  writeEvents(events);
+}

--- a/scripts/purgeExperimentData.ts
+++ b/scripts/purgeExperimentData.ts
@@ -1,0 +1,4 @@
+import { purgeExpiredExperimentData } from '../lib/analytics';
+
+purgeExpiredExperimentData();
+console.log('Stale experiment data purged');


### PR DESCRIPTION
## Summary
- add analytics utility to capture events with experiment metadata and TTL
- include purge script to remove expired experiment data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6bd8514488328a417f53ebe41b7a1