### PR TITLE
feat: add Entra ID auth configuration

### DIFF
--- a/authOptions.ts
+++ b/authOptions.ts
@@ -1,11 +1,22 @@
 import type { AuthOptions, SessionStrategy } from "next-auth";
 import type { Adapter } from "next-auth/adapters";
+import AzureADProvider from "next-auth/providers/azure-ad";
 
 const isProd = process.env.NODE_ENV === "production";
 
 // Allow choosing between JWT and database sessions via environment variable
 const sessionStrategy: SessionStrategy =
   process.env.SESSION_STRATEGY === "database" ? "database" : "jwt";
+
+const groupRoleMap: Record<string, string> = {
+  [process.env.AZURE_AD_ADMIN_GROUP_ID ?? ""]: "admin",
+  [process.env.AZURE_AD_USER_GROUP_ID ?? ""]: "user",
+};
+
+const mapGroupsToRoles = (groups: string[]): string[] => {
+  const roles = groups.map((g) => groupRoleMap[g]).filter(Boolean) as string[];
+  return Array.from(new Set(roles));
+};
 
 export const buildAuthOptions = (adapter?: Adapter): AuthOptions => {
   const options: AuthOptions = {
@@ -19,6 +30,28 @@ export const buildAuthOptions = (adapter?: Adapter): AuthOptions => {
           httpOnly: true,
           sameSite: "lax",
         },
+      },
+    },
+    providers: [
+      AzureADProvider({
+        clientId: process.env.AZURE_AD_CLIENT_ID ?? "",
+        clientSecret: process.env.AZURE_AD_CLIENT_SECRET ?? "",
+        tenantId: process.env.AZURE_AD_TENANT_ID,
+      }),
+    ],
+    callbacks: {
+      jwt: async ({ token, profile }) => {
+        const groups = (profile as any)?.groups as string[] | undefined;
+        if (groups) {
+          token.roles = mapGroupsToRoles(groups);
+        }
+        return token;
+      },
+      session: async ({ session, token }) => {
+        if (token.roles) {
+          (session.user as any).roles = token.roles;
+        }
+        return session;
       },
     },
   };

--- a/docs/entra-setup.md
+++ b/docs/entra-setup.md
@@ -1,0 +1,27 @@
+# Entra Setup
+
+This project uses Microsoft Entra ID for authentication via NextAuth.
+
+## Application registration
+
+1. Sign in to the Azure portal.
+2. Navigate to **Microsoft Entra ID** > **App registrations** > **New registration**.
+3. Provide a name, choose supported account types, and set a redirect URI for your deployment.
+4. After the app is created, record the following values from the overview page:
+   - **Tenant ID** ("Directory (tenant) ID")
+   - **Client ID** ("Application (client) ID")
+5. Create a client secret under **Certificates & secrets** and copy the value.
+
+## Environment variables
+
+Add the values to your environment configuration:
+
+```
+AZURE_AD_TENANT_ID=<tenant-id>
+AZURE_AD_CLIENT_ID=<client-id>
+AZURE_AD_CLIENT_SECRET=<client-secret>
+AZURE_AD_ADMIN_GROUP_ID=<group-id-for-admin>
+AZURE_AD_USER_GROUP_ID=<group-id-for-user>
+```
+
+For role mapping based on group claims, ensure your application manifest sets `groupMembershipClaims` to `SecurityGroup` so group IDs are included in the ID token.


### PR DESCRIPTION
## Summary
- add Microsoft Entra ID provider to NextAuth options
- map Entra group claims to application roles
- document tenant, client, and group ID setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6bd871cd08328a73877b1577e6bba