### PR TITLE
Add experiment variant middleware and analytics reporting

### DIFF
--- a/database.js
+++ b/database.js
@@ -13,6 +13,8 @@ function initDb() {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       lease_id TEXT,
       event TEXT,
+      experiment_id TEXT,
+      variant_id TEXT,
       timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
     )`);
   });
@@ -34,10 +36,18 @@ function getStatuses(leaseId, cb) {
   );
 }
 
-function logEvent(leaseId, event) {
+function logEvent(leaseId, event, experimentId = null, variantId = null) {
   db.run(
-    'INSERT INTO events (lease_id, event) VALUES (?, ?)',
-    [leaseId, event]
+    'INSERT INTO events (lease_id, event, experiment_id, variant_id) VALUES (?, ?, ?, ?)',
+    [leaseId, event, experimentId, variantId]
+  );
+}
+
+function getConversionMetrics(experimentId, cb) {
+  db.all(
+    'SELECT variant_id, COUNT(*) as conversions FROM events WHERE experiment_id = ? AND event = ? GROUP BY variant_id',
+    [experimentId, 'conversion'],
+    (err, rows) => cb(err, rows)
   );
 }
 
@@ -46,4 +56,5 @@ module.exports = {
   addStatus,
   getStatuses,
   logEvent,
+  getConversionMetrics,
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,10 +22,19 @@ export function middleware(request: NextRequest) {
     }
   }
 
-  return NextResponse.next();
+  // Assign experiment variant if one is not already set.
+  const response = NextResponse.next();
+  const experimentCookie = request.cookies.get('experiment-variant');
+
+  if (!experimentCookie) {
+    const variant = Math.random() < 0.5 ? 'control' : 'test';
+    response.cookies.set('experiment-variant', variant, { path: '/' });
+  }
+
+  return response;
 }
 
 export const config = {
-  matcher: ['/tenant/:path*', '/admin/:path*'],
+  matcher: ['/:path*'],
 };
 

--- a/pages/api/analytics.ts
+++ b/pages/api/analytics.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { logEvent } from '../../database';
+
+export default function analytics(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const { leaseId = '', event, experimentId } = req.body || {};
+  const variantId = req.cookies['experiment-variant'] || null;
+
+  if (!event || !experimentId) {
+    return res.status(400).json({ error: 'Missing event or experimentId' });
+  }
+
+  logEvent(leaseId, event, experimentId, variantId);
+  return res.status(200).json({ success: true });
+}

--- a/pages/report.tsx
+++ b/pages/report.tsx
@@ -1,0 +1,45 @@
+import { GetServerSideProps } from 'next';
+import { getConversionMetrics } from '../database';
+
+interface Metric {
+  variant_id: string;
+  conversions: number;
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  const metrics: Metric[] = await new Promise((resolve) => {
+    getConversionMetrics('experiment-1', (err, rows) => {
+      if (err) {
+        resolve([]);
+      } else {
+        resolve(rows as Metric[]);
+      }
+    });
+  });
+
+  return { props: { metrics } };
+};
+
+export default function ReportPage({ metrics }: { metrics: Metric[] }) {
+  return (
+    <div>
+      <h1>Experiment Report</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Variant</th>
+            <th>Conversions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {metrics.map((m) => (
+            <tr key={m.variant_id}>
+              <td>{m.variant_id}</td>
+              <td>{m.conversions}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Assign experiment variants via middleware cookie
- Log analytics events with experiment and variant IDs
- Provide report page aggregating conversion metrics per variant

## Testing
- `npm test`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6bd80f6b48328be2cccef3ef47378