### PR TITLE
feat: add feature flags for autopay and ACH

### DIFF
--- a/app/api/billing/payment-intents/route.ts
+++ b/app/api/billing/payment-intents/route.ts
@@ -1,11 +1,15 @@
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { autopayEnabled } from '@/lib/flags';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
   apiVersion: '2022-11-15',
 });
 
 export async function POST(request: Request) {
+  if (!autopayEnabled) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
   try {
     const { amount } = await request.json();
 

--- a/app/api/pay/verify-bank/route.ts
+++ b/app/api/pay/verify-bank/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { achEnabled } from '@/lib/flags';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: '2024-04-10',
@@ -10,6 +11,9 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
  * Supports both instant verification and micro‑deposit flows.
  */
 export async function POST(req: Request) {
+  if (!achEnabled) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
   const { intentId, type = 'payment', amounts } = await req.json();
 
   try {

--- a/app/pay/page.tsx
+++ b/app/pay/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { loadStripe } from '@stripe/stripe-js';
 import { Elements, PaymentElement } from '@stripe/react-stripe-js';
 import type { StripeElementsOptions } from '@stripe/stripe-js';
+import { autopayEnabled, achEnabled } from '@/lib/flags';
 
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
 
@@ -11,17 +12,22 @@ export default function PayPage() {
   const [clientSecret, setClientSecret] = useState<string>('');
 
   useEffect(() => {
+    if (!autopayEnabled) return;
     fetch('/api/pay').then(async (res) => {
       const data = await res.json();
       setClientSecret(data.clientSecret);
     });
   }, []);
 
+  if (!autopayEnabled) {
+    return null;
+  }
+
   const options: StripeElementsOptions = {
     clientSecret,
     appearance: { theme: 'stripe' },
     // Enable US bank account payments alongside cards
-    paymentMethodOrder: ['card', 'us_bank_account'],
+    paymentMethodOrder: achEnabled ? ['card', 'us_bank_account'] : ['card'],
   };
 
   return (
@@ -30,12 +36,14 @@ export default function PayPage() {
         <Elements options={options} stripe={stripePromise}>
           <PaymentElement />
           {/* Required ACH mandate text for US bank account payments */}
-          <p className="mt-4 text-xs text-gray-600" id="ach-mandate">
-            By providing your bank account information and confirming this payment, you authorize
-            our company and Stripe to debit your account. If necessary, Stripe may electronically
-            credit your account to correct erroneous debits. You acknowledge that ACH payments are
-            subject to U.S. banking laws and NACHA operating rules.
-          </p>
+          {achEnabled && (
+            <p className="mt-4 text-xs text-gray-600" id="ach-mandate">
+              By providing your bank account information and confirming this payment, you authorize
+              our company and Stripe to debit your account. If necessary, Stripe may electronically
+              credit your account to correct erroneous debits. You acknowledge that ACH payments are
+              subject to U.S. banking laws and NACHA operating rules.
+            </p>
+          )}
         </Elements>
       )}
     </div>

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,0 +1,13 @@
+function isEnabled(name: string): boolean {
+  return process.env[name] === 'true';
+}
+
+export const features = {
+  autopay: isEnabled('NEXT_PUBLIC_FLAG_AUTOPAY'),
+  ach: isEnabled('NEXT_PUBLIC_FLAG_ACH'),
+  experimentalSearch: isEnabled('NEXT_PUBLIC_FLAG_SEARCH'),
+};
+
+export const autopayEnabled = features.autopay;
+export const achEnabled = features.ach;
+export const experimentalSearchEnabled = features.experimentalSearch;


### PR DESCRIPTION
## Summary
- introduce shared feature-flag utilities
- guard autopay and ACH flows behind flags
- add placeholder flag for experimental search work

## Testing
- `npm test`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6bd7f94888328825b1c6b66910a11