### PR TITLE
feat: add feature flag client and middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,23 @@ Set environment variables for AWS to use S3:
 export AWS_REGION=us-east-1
 export S3_BUCKET=your-bucket
 ```
+
+## Feature Flags
+
+Feature flags can be supplied by either [Unleash](https://www.getunleash.io/) or [Vercel Edge Config](https://vercel.com/docs/edge-network/edge-config).
+Set the relevant environment variables for the provider you use:
+
+### Unleash
+
+```
+export UNLEASH_API_URL=https://unleash.example.com/api
+export UNLEASH_API_TOKEN=your-token
+```
+
+### Edge Config
+
+```
+export EDGE_CONFIG_URL=https://edge-config.vercel.com/<id>/config
+```
+
+Flags are fetched on each request by the middleware and exposed to the application via the `x-feature-flags` request header.

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,0 +1,50 @@
+export type Flags = Record<string, unknown>;
+
+/**
+ * Retrieve feature flags from either Unleash or Edge Config.
+ *
+ * When `UNLEASH_API_URL` and `UNLEASH_API_TOKEN` are set, flags are fetched from
+ * the Unleash client API. Otherwise, when `EDGE_CONFIG_URL` is set, flags are
+ * fetched from a Vercel Edge Config endpoint. If neither is configured an empty
+ * object is returned.
+ */
+export async function getFlags(): Promise<Flags> {
+  if (process.env.UNLEASH_API_URL && process.env.UNLEASH_API_TOKEN) {
+    try {
+      const res = await fetch(`${process.env.UNLEASH_API_URL}/client/features`, {
+        headers: {
+          Authorization: process.env.UNLEASH_API_TOKEN,
+        },
+        cache: 'no-store',
+      });
+      if (!res.ok) {
+        return {};
+      }
+      const data = await res.json();
+      const flags: Flags = {};
+      if (Array.isArray(data.features)) {
+        for (const feature of data.features) {
+          flags[feature.name] = feature.enabled;
+        }
+      }
+      return flags;
+    } catch (err) {
+      return {};
+    }
+  }
+
+  if (process.env.EDGE_CONFIG_URL) {
+    try {
+      const res = await fetch(process.env.EDGE_CONFIG_URL, {
+        cache: 'no-store',
+      });
+      if (res.ok) {
+        return await res.json();
+      }
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  return {};
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,19 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { getFlags } from './lib/flags';
 
 /**
- * Middleware to protect tenant and admin routes.
+ * Middleware to protect tenant and admin routes and inject feature flags.
  * Users must have an auth token cookie to access these paths.
  * Unauthenticated users are redirected to /login.
+ * Feature flags are added to the request headers as a JSON string under
+ * `x-feature-flags`.
  */
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
+  const flags = await getFlags();
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-feature-flags', JSON.stringify(flags));
+
   const { pathname } = request.nextUrl;
 
   const requiresAuth = pathname.startsWith('/tenant') || pathname.startsWith('/admin');
@@ -22,10 +29,13 @@ export function middleware(request: NextRequest) {
     }
   }
 
-  return NextResponse.next();
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
 }
 
 export const config = {
   matcher: ['/tenant/:path*', '/admin/:path*'],
 };
-


### PR DESCRIPTION
## Summary
- add feature flag client supporting Unleash and Edge Config
- fetch flags per request in middleware and expose via request headers
- document feature flag environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6bd7f30c4832896cd1e3f74b23248